### PR TITLE
Implement dual-write neutral fields and sync enhancements

### DIFF
--- a/apps/web/src/components/calendar/day-column.tsx
+++ b/apps/web/src/components/calendar/day-column.tsx
@@ -11,12 +11,14 @@ import { BookingBlock } from "./booking-block";
 import { EventCard } from "./event-card";
 import { GhostEvent } from "./ghost-event";
 import {
+  LANE_TILE_MAX_STAGGER_MS,
   layoutDayEvents,
   MS_PER_DAY,
   MS_PER_MINUTE,
   SNAP_MS,
   SNAP_MINUTES,
   snappedMsFromOffsetY,
+  WEEK_LANE_TILE_MAX_STAGGER_MS,
   type CalendarEvent,
 } from "./lib";
 import type { Reveal } from "./today-pulse";
@@ -103,9 +105,15 @@ function DayColumnImpl({
       ? view
       : null;
 
+  // Week columns cascade and tile more eagerly than the wider day column; the
+  // threshold that flips a close-starting overlap from cascade to side-by-side
+  // tiles follows the same laneLayout switch used for rendering.
+  const tileMaxStaggerMs = laneLayout
+    ? LANE_TILE_MAX_STAGGER_MS
+    : WEEK_LANE_TILE_MAX_STAGGER_MS;
   const positioned = useMemo(
-    () => layoutDayEvents(events, dayStartMs),
-    [events, dayStartMs],
+    () => layoutDayEvents(events, dayStartMs, tileMaxStaggerMs),
+    [events, dayStartMs, tileMaxStaggerMs],
   );
 
   useEffect(() => {

--- a/apps/web/src/components/calendar/event-card.tsx
+++ b/apps/web/src/components/calendar/event-card.tsx
@@ -49,28 +49,42 @@ export function EventCard({
   reveal,
   onDragStart,
 }: EventCardProps) {
-  const { event, topPct, heightPct, stackIndex, elevation, columnIndex, columnCount, columnSpan } =
-    positioned;
+  const {
+    event,
+    topPct,
+    heightPct,
+    stackIndex,
+    elevation,
+    columnIndex,
+    columnCount,
+    columnSpan,
+    laneAdvance,
+  } = positioned;
   const colorFor = useEventColor();
   const colorVar = colorFor(event);
   // An event the user can't reschedule still opens on tap, but it shouldn't
   // offer a grab cursor or resize edges for a drag that will never happen.
   const { canEdit: draggable, canSeeGuests } = useEventCapabilities()(event);
   const attendees = canSeeGuests ? (event.attendees ?? []).slice(0, 3) : [];
-  // Two overlap modes. Lanes (day view): each cluster fans into side-by-side
-  // lanes that partially overlap, so a card exposes its own left edge while the
-  // later card paints on top — spread out, but still visibly stacked. Cascade
-  // (week view): each deeper card is indented right with its right edge pinned,
-  // so cards behind peek out on the left — the column is too narrow to fan.
+  // Two overlap modes. Lanes: each cluster fans into side-by-side lanes that
+  // partially overlap, so a card exposes its own left edge while the later card
+  // paints on top — spread out, but still visibly stacked. Cascade: each deeper
+  // card is indented right with its right edge pinned, so cards behind peek out
+  // on the left. Day view always uses lanes; week columns are too narrow to fan
+  // and cascade instead — except a cluster whose starts sit too close to stagger
+  // cleanly (laneAdvance === 1, see layoutDayEvents) tiles into clean columns in
+  // both views, so the later card never buries the earlier one's title/time.
+  const tiled = laneAdvance === 1;
+  const useLanes = laneLayout || tiled;
   const indent = stackIndentPx(stackIndex);
-  const box = laneBox(columnIndex, columnCount, columnSpan);
+  const box = laneBox(columnIndex, columnCount, columnSpan, laneAdvance);
   // A fixed strip is reserved on the left of the column (see EVENT_LEFT_GUTTER_PX):
   // the fractional lane box is squeezed into the space right of it, so cards still
   // fan out and end flush on the right while the left edge stays free for painting
   // a neighbouring event. `gutter` is that reserved width; `avail` is what's left.
   const gutter = `${EVENT_LEFT_GUTTER_PX}px`;
   const avail = `(100% - ${gutter})`;
-  const horizontal = laneLayout
+  const horizontal = useLanes
     ? {
         left: `calc(${gutter} + ${box.left} * ${avail} + 2px)`,
         width: `calc(${box.width} * ${avail} - 4px)`,

--- a/apps/web/src/components/calendar/event-card.tsx
+++ b/apps/web/src/components/calendar/event-card.tsx
@@ -6,7 +6,12 @@ import { motion } from "motion/react";
 
 import { Avatar } from "./avatar";
 import { useEventColor } from "./colors";
-import { laneBox, type PositionedEvent, stackIndentPx } from "./lib";
+import {
+  EVENT_LEFT_GUTTER_PX,
+  laneBox,
+  type PositionedEvent,
+  stackIndentPx,
+} from "./lib";
 import { pressTransition } from "./motion";
 import { useEventCapabilities } from "./permissions";
 import { RevealFlash, type Reveal } from "./today-pulse";
@@ -59,14 +64,20 @@ export function EventCard({
   // so cards behind peek out on the left — the column is too narrow to fan.
   const indent = stackIndentPx(stackIndex);
   const box = laneBox(columnIndex, columnCount, columnSpan);
+  // A fixed strip is reserved on the left of the column (see EVENT_LEFT_GUTTER_PX):
+  // the fractional lane box is squeezed into the space right of it, so cards still
+  // fan out and end flush on the right while the left edge stays free for painting
+  // a neighbouring event. `gutter` is that reserved width; `avail` is what's left.
+  const gutter = `${EVENT_LEFT_GUTTER_PX}px`;
+  const avail = `(100% - ${gutter})`;
   const horizontal = laneLayout
     ? {
-        left: `calc(${box.left * 100}% + 2px)`,
-        width: `calc(${box.width * 100}% - 4px)`,
+        left: `calc(${gutter} + ${box.left} * ${avail} + 2px)`,
+        width: `calc(${box.width} * ${avail} - 4px)`,
       }
     : {
-        left: `calc(${indent}px + 2px)`,
-        width: `calc(100% - ${indent}px - 4px)`,
+        left: `calc(${gutter} + ${indent}px + 2px)`,
+        width: `calc(${avail} - ${indent}px - 4px)`,
       };
   // The card is a size-query container (see `.event-card` in globals.css): the
   // start time and title shrink out as the rendered height gets small, so short

--- a/apps/web/src/components/calendar/lib.test.ts
+++ b/apps/web/src/components/calendar/lib.test.ts
@@ -6,7 +6,9 @@ import {
   calendarDisplayName,
   type CalendarEvent,
   formatWallClockMinutes,
+  LANE_ADVANCE_RATIO,
   laneBox,
+  WEEK_LANE_TILE_MAX_STAGGER_MS,
   layoutAllDayEvents,
   layoutDayEvents,
   visibleAllDayMetrics,
@@ -347,6 +349,95 @@ describe("layoutDayEvents columns", () => {
   });
 });
 
+describe("layoutDayEvents overlap style", () => {
+  const byId = (layout: ReturnType<typeof layoutDayEvents>) =>
+    Object.fromEntries(layout.map((p) => [String(p.event._id), p]));
+
+  test("a comfortable stagger keeps the overlapping fan", () => {
+    // Starts an hour apart: the later card sits well below the earlier one's
+    // header, so the prettier fan (advance < 1) is retained.
+    const layout = byId(
+      layoutDayEvents(
+        [timedEvent("a", 11, 15, 14, 0), timedEvent("b", 12, 15, 13, 30)],
+        dayStart,
+      ),
+    );
+
+    expect(layout.a.laneAdvance).toBeCloseTo(LANE_ADVANCE_RATIO, 5);
+    expect(layout.b.laneAdvance).toBeCloseTo(LANE_ADVANCE_RATIO, 5);
+  });
+
+  test("a close stagger tiles the cluster into clean columns", () => {
+    // Starts 15 minutes apart: the fan's later card would land on the earlier
+    // one's header, so both switch to full side-by-side tiling (advance 1).
+    const layout = byId(
+      layoutDayEvents(
+        [timedEvent("a", 11, 15, 14, 0), timedEvent("b", 11, 30, 12, 45)],
+        dayStart,
+      ),
+    );
+
+    expect(layout.a.laneAdvance).toBe(1);
+    expect(layout.b.laneAdvance).toBe(1);
+    // Tiled columns don't overlap: card b's left edge starts at card a's right.
+    const a = laneBox(layout.a.columnIndex, layout.a.columnCount, layout.a.columnSpan, layout.a.laneAdvance);
+    const b = laneBox(layout.b.columnIndex, layout.b.columnCount, layout.b.columnSpan, layout.b.laneAdvance);
+    expect(a.left + a.width).toBeCloseTo(b.left, 5);
+  });
+
+  test("a wider stagger threshold (week view) tiles a pair the default keeps fanned", () => {
+    // 40 minutes apart: above the 30-min day default (stays a fan) but within a
+    // 45-min week threshold (tiles). Same events, different threshold argument.
+    const events = [
+      timedEvent("a", 11, 0, 14, 0),
+      timedEvent("b", 11, 40, 13, 0),
+    ];
+
+    const dayLayout = byId(layoutDayEvents(events, dayStart));
+    expect(dayLayout.a.laneAdvance).toBeCloseTo(LANE_ADVANCE_RATIO, 5);
+
+    const weekLayout = byId(
+      layoutDayEvents(events, dayStart, WEEK_LANE_TILE_MAX_STAGGER_MS),
+    );
+    expect(weekLayout.a.laneAdvance).toBe(1);
+    expect(weekLayout.b.laneAdvance).toBe(1);
+  });
+
+  test("a whole cluster tiles when any overlapping pair starts too close", () => {
+    // a↔b are an hour apart (fan-friendly), but c starts right on top of b, so
+    // the entire transitively-linked cluster tiles for consistency.
+    const layout = byId(
+      layoutDayEvents(
+        [
+          timedEvent("a", 9, 0, 12, 0),
+          timedEvent("b", 10, 0, 12, 0),
+          timedEvent("c", 10, 10, 12, 0),
+        ],
+        dayStart,
+      ),
+    );
+
+    expect(layout.a.laneAdvance).toBe(1);
+    expect(layout.b.laneAdvance).toBe(1);
+    expect(layout.c.laneAdvance).toBe(1);
+  });
+
+  test("events that don't overlap in time never tile on a close start alone", () => {
+    // Back-to-back events (same start distance as a tiling case would use) don't
+    // overlap, so they aren't clustered and keep the default fan advance.
+    const layout = byId(
+      layoutDayEvents(
+        [timedEvent("a", 9, 0, 9, 30), timedEvent("b", 9, 30, 10, 0)],
+        dayStart,
+      ),
+    );
+
+    expect(layout.a.columnCount).toBe(1);
+    expect(layout.a.laneAdvance).toBeCloseTo(LANE_ADVANCE_RATIO, 5);
+    expect(layout.b.laneAdvance).toBeCloseTo(LANE_ADVANCE_RATIO, 5);
+  });
+});
+
 describe("laneBox", () => {
   test("a lone card fills the whole column", () => {
     expect(laneBox(0, 1, 1)).toEqual({ left: 0, width: 1 });
@@ -361,6 +452,16 @@ describe("laneBox", () => {
     expect(a.left).toBe(0);
     // The second card starts before the midpoint and ends flush at the right.
     expect(b.left).toBeLessThan(0.5);
+    expect(b.left + b.width).toBeCloseTo(1, 5);
+  });
+
+  test("advance 1 tiles lanes into clean, equal, non-overlapping halves", () => {
+    const a = laneBox(0, 2, 1, 1);
+    const b = laneBox(1, 2, 1, 1);
+
+    expect(a.left).toBe(0);
+    expect(a.width).toBeCloseTo(0.5, 5);
+    expect(b.left).toBeCloseTo(0.5, 5);
     expect(b.left + b.width).toBeCloseTo(1, 5);
   });
 

--- a/apps/web/src/components/calendar/lib.ts
+++ b/apps/web/src/components/calendar/lib.ts
@@ -517,6 +517,11 @@ export interface PositionedEvent {
   /** How many columns the card fills once it expands right into free space
    * (>= 1). `columnIndex + columnSpan <= columnCount`. */
   columnSpan: number;
+  /** Fraction of a card's width the next lane advances by, in side-by-side
+   * (lane) layout. {@link LANE_ADVANCE_RATIO} for the overlapping fan, or 1 when
+   * the cluster tiles into clean non-overlapping columns (see the tiling rule in
+   * {@link layoutDayEvents}). Shared by every card in a cluster. */
+  laneAdvance: number;
 }
 
 /** Blank strip reserved on the left edge of every day column, so a card never
@@ -547,22 +552,39 @@ export function stackIndentPx(stackIndex: number): number {
  * read as a stack rather than splitting into clean, disconnected halves. */
 export const LANE_ADVANCE_RATIO = 0.62;
 
+/** When two overlapping cards start within this window, the fan's later card
+ * lands on the earlier one's header and hides its title/time. The cluster then
+ * tiles into clean, equal columns instead (advance ratio 1). Kept a touch above
+ * the header's on-screen height at the grid's minimum zoom, so the switch fires
+ * whenever the stagger is too small to keep both cards' details readable — and
+ * errs toward tiling (fully readable) rather than a covered header. */
+export const LANE_TILE_MAX_STAGGER_MS = 30 * MS_PER_MINUTE;
+
+/** Week-view counterpart of {@link LANE_TILE_MAX_STAGGER_MS}. Its narrower
+ * columns cascade rather than fan, and a cascaded card's left sliver is thinner
+ * than a fanned lane's exposed edge, so a covered header reads worse there —
+ * hence a wider window that tiles more eagerly. */
+export const WEEK_LANE_TILE_MAX_STAGGER_MS = 45 * MS_PER_MINUTE;
+
 /** Horizontal box (`left`/`width` as 0–1 fractions of the column) for an event
  * laid out in side-by-side lanes. Cards fan left-to-right and overlap by
- * `1 - LANE_ADVANCE_RATIO` of their width, so each exposes its own left edge
- * while the later card (painted on top) still overlaps it. A card widens across
+ * `1 - advance` of their width, so each exposes its own left edge while the
+ * later card (painted on top) still overlaps it. At `advance` 1 the cards tile
+ * into clean, equal columns with no horizontal overlap (used when a close
+ * stagger would otherwise hide a card's header). A card widens across
  * `columnSpan` lanes when it can expand right into free space; a card that
  * reaches the last lane extends to the column's right edge. */
 export function laneBox(
   columnIndex: number,
   columnCount: number,
   columnSpan: number,
+  advance: number = LANE_ADVANCE_RATIO,
 ): { left: number; width: number } {
   if (columnCount <= 1) return { left: 0, width: 1 };
-  // Width W and step S solve (columnCount-1)·S + W = 1 with S = ratio·W, so the
+  // Width W and step S solve (columnCount-1)·S + W = 1 with S = advance·W, so the
   // fan exactly spans the column and the rightmost card ends flush.
-  const width = 1 / (1 + (columnCount - 1) * LANE_ADVANCE_RATIO);
-  const step = LANE_ADVANCE_RATIO * width;
+  const width = 1 / (1 + (columnCount - 1) * advance);
+  const step = advance * width;
   return { left: columnIndex * step, width: width + (columnSpan - 1) * step };
 }
 
@@ -576,6 +598,7 @@ export function laneBox(
 export function layoutDayEvents(
   events: CalendarEvent[],
   dayStartMs: number,
+  tileMaxStaggerMs: number = LANE_TILE_MAX_STAGGER_MS,
 ): PositionedEvent[] {
   const dayEndMs = dayStartMs + MS_PER_DAY;
   const items = events
@@ -592,6 +615,7 @@ export function layoutDayEvents(
         columnIndex: 0,
         columnCount: 1,
         columnSpan: 1,
+        laneAdvance: LANE_ADVANCE_RATIO,
       };
     })
     .sort((a, b) => a.start - b.start || b.end - b.start - (a.end - a.start));
@@ -631,6 +655,28 @@ export function layoutDayEvents(
       item.columnSpan = Math.max(span, 1);
     }
 
+    // Choose the overlap style for the whole cluster. The fan (cards partially
+    // overlapping, each peeking out on the left) reads best when a comfortable
+    // vertical stagger keeps every earlier card's header above the next card's
+    // top edge. But when two time-overlapping cards start within
+    // LANE_TILE_MAX_STAGGER_MS, the later card lands on the earlier one's
+    // header and buries its title/time — so tile the cluster into clean, equal
+    // columns (advance 1, no horizontal overlap) where both stay readable.
+    let tiled = false;
+    for (let i = 0; i < cluster.length && !tiled; i++) {
+      for (let j = i + 1; j < cluster.length; j++) {
+        const a = cluster[i];
+        const b = cluster[j];
+        const overlap = a.start < b.end && b.start < a.end;
+        if (overlap && Math.abs(a.start - b.start) < tileMaxStaggerMs) {
+          tiled = true;
+          break;
+        }
+      }
+    }
+    const advance = tiled ? 1 : LANE_ADVANCE_RATIO;
+    for (const item of cluster) item.laneAdvance = advance;
+
     cluster = [];
   };
 
@@ -656,6 +702,7 @@ export function layoutDayEvents(
       columnIndex,
       columnCount,
       columnSpan,
+      laneAdvance,
     }) => ({
       event,
       topPct: msToPct(start, dayStartMs),
@@ -666,6 +713,7 @@ export function layoutDayEvents(
       columnIndex,
       columnCount,
       columnSpan,
+      laneAdvance,
     }),
   );
 }

--- a/apps/web/src/components/calendar/lib.ts
+++ b/apps/web/src/components/calendar/lib.ts
@@ -519,6 +519,13 @@ export interface PositionedEvent {
   columnSpan: number;
 }
 
+/** Blank strip reserved on the left edge of every day column, so a card never
+ * covers the column's left border. It leaves an always-clickable lane for
+ * starting a drag-create right next to (or overlapping) an existing event —
+ * otherwise a full-width card swallows the pointer-down and you can't paint a
+ * neighbour without first finding a gap. */
+export const EVENT_LEFT_GUTTER_PX = 12;
+
 /** Horizontal shift, in pixels, applied per stack level in the overlap cascade. */
 export const STACK_INDENT_PX = 14;
 /** Stack levels that get the full indent before it stops growing. */

--- a/packages/backend/convex/_generated/api.d.ts
+++ b/packages/backend/convex/_generated/api.d.ts
@@ -30,6 +30,7 @@ import type * as domains_booking_mutations from "../domains/booking/mutations.js
 import type * as domains_booking_queries from "../domains/booking/queries.js";
 import type * as domains_booking_service from "../domains/booking/service.js";
 import type * as domains_booking_tables from "../domains/booking/tables.js";
+import type * as domains_calendar_connections from "../domains/calendar/connections.js";
 import type * as domains_calendar_model from "../domains/calendar/model.js";
 import type * as domains_calendar_mutations from "../domains/calendar/mutations.js";
 import type * as domains_calendar_queries from "../domains/calendar/queries.js";
@@ -98,6 +99,7 @@ declare const fullApi: ApiFromModules<{
   "domains/booking/queries": typeof domains_booking_queries;
   "domains/booking/service": typeof domains_booking_service;
   "domains/booking/tables": typeof domains_booking_tables;
+  "domains/calendar/connections": typeof domains_calendar_connections;
   "domains/calendar/model": typeof domains_calendar_model;
   "domains/calendar/mutations": typeof domains_calendar_mutations;
   "domains/calendar/queries": typeof domains_calendar_queries;

--- a/packages/backend/convex/backfillConnections.ts
+++ b/packages/backend/convex/backfillConnections.ts
@@ -22,32 +22,10 @@ import {
   internalQuery,
   type MutationCtx,
 } from "./_generated/server";
+import { ensureGoogleConnection } from "./domains/calendar/connections";
 
 const USER_BATCH = 50;
 const ROW_BATCH = 500;
-
-/** Find or create the user's single Google connection (connection == login grant). */
-async function ensureConnection(
-  ctx: MutationCtx,
-  userId: string,
-): Promise<Id<"calendarConnections">> {
-  const existing = await ctx.db
-    .query("calendarConnections")
-    .withIndex("by_user_and_provider", (q) =>
-      q.eq("userId", userId).eq("provider", "google"),
-    )
-    .first();
-  if (existing) return existing._id;
-  const now = Date.now();
-  return await ctx.db.insert("calendarConnections", {
-    userId,
-    provider: "google",
-    status: "active",
-    capabilities: { contacts: true, idempotentCreate: true },
-    createdAt: now,
-    updatedAt: now,
-  });
-}
 
 /** Copy the user's single `syncState` row into a connection-scoped one. */
 async function ensureConnectionSyncState(
@@ -112,7 +90,7 @@ export const enqueueConnectionBackfill = internalMutation({
 export const backfillUser = internalMutation({
   args: { userId: v.string() },
   handler: async (ctx, args): Promise<null> => {
-    const connectionId = await ensureConnection(ctx, args.userId);
+    const connectionId = await ensureGoogleConnection(ctx, args.userId);
     await ensureConnectionSyncState(ctx, args.userId, connectionId);
 
     const calendars = await ctx.db

--- a/packages/backend/convex/booking.itest.ts
+++ b/packages/backend/convex/booking.itest.ts
@@ -244,6 +244,9 @@ describe("booking acceptance settle", () => {
     const row = await t.run((ctx) => ctx.db.get(bookingId));
     expect(row!.status).toBe("accepted");
     expect(row!.googleEventId).toBe("evt_google");
+    // Dual-write: the neutral mirror is stamped alongside the Google id.
+    expect(row!.connectionId).toBeDefined();
+    expect(row!.providerEventId).toBe("evt_google");
     expect(row!.acceptAttemptId).toBeUndefined();
     expect(row!.acceptLeaseExpiresAt).toBeUndefined();
     expect(row!.acceptMayHaveSucceeded).toBeUndefined();

--- a/packages/backend/convex/domains/booking/mutations.ts
+++ b/packages/backend/convex/domains/booking/mutations.ts
@@ -16,6 +16,7 @@ import type { MutationCtx } from "../../_generated/server";
 import { authComponent } from "../../auth";
 import { googleEventIdForOperation } from "../../lib/assistantLogic";
 import { consumeRateLimit } from "../../infrastructure/rateLimit";
+import { ensureGoogleConnection } from "../calendar/connections";
 import { clearBookingNotifications } from "../notifications/model";
 import {
   ACCEPT_LEASE_MS,
@@ -213,6 +214,9 @@ export async function requestBookingHandler(
   }
 
   const token = crypto.randomUUID();
+  // Dual-write: stamp the host's connection so the row matches the backfilled
+  // ones. providerEventId is set later, when acceptance creates the event.
+  const connectionId = await ensureGoogleConnection(ctx, page.userId);
   const bookingId = await ctx.db.insert("bookings", {
     hostUserId: page.userId,
     startMs: args.startMs,
@@ -223,6 +227,7 @@ export async function requestBookingHandler(
     note: note || undefined,
     status: "pending",
     token,
+    connectionId,
     createdAt: Date.now(),
   });
   // Surface the request in the host's notification bell. Times render in the
@@ -310,10 +315,14 @@ export async function markAcceptedHandler(
   ) {
     return false;
   }
+  // Dual-write the neutral mirror of the created event alongside the Google id.
+  const connectionId = await ensureGoogleConnection(ctx, args.hostUserId);
   await ctx.db.patch(args.bookingId, {
     status: "accepted",
     googleEventId: args.googleEventId,
     calendarId: args.calendarId,
+    connectionId,
+    providerEventId: args.googleEventId,
     decidedAt: Date.now(),
     acceptAttemptId: undefined,
     acceptLeaseExpiresAt: undefined,

--- a/packages/backend/convex/domains/booking/service.ts
+++ b/packages/backend/convex/domains/booking/service.ts
@@ -1,28 +1,24 @@
 /**
- * Booking acceptance — the one booking operation that talks to Google, so it is
- * an action, not a mutation. The root `booking.ts` wraps this handler in a
- * Convex `action` at `api.booking.acceptBooking`.
+ * Booking acceptance — the one booking operation that talks to a calendar
+ * provider, so it is an action, not a mutation. The root `booking.ts` wraps this
+ * handler in a Convex `action` at `api.booking.acceptBooking`.
  *
- * It reuses `calendar.createEvent`'s sequence: resolve a token through the
- * credential broker, pick the primary calendar, insert with the requester as a
- * guest and `sendUpdates:"all"` (Google's own invitation email is the
- * confirmation — we send none), then mirror the row so the card appears now.
+ * The calendar write goes through the provider adapter (via the registry), so
+ * this path is provider-neutral: `createEventReconciling` creates the event and,
+ * on an ambiguous/conflict failure, reconciles by the operation's idempotency
+ * key instead of risking a duplicate. The claim/mark/release lease around it is
+ * unchanged. `notify:"all"` makes the provider send its own invitation email,
+ * which is the requester's confirmation — the app sends none.
  */
 
 import { internal } from "../../_generated/api";
 import type { Id } from "../../_generated/dataModel";
 import type { ActionCtx } from "../../_generated/server";
 import { authComponent } from "../../auth";
-import { googleEventIdForOperation } from "../../lib/assistantLogic";
-import { getGoogleAccessToken } from "../../lib/googleCredentials";
-import {
-  getCalendarEvent,
-  GoogleApiError,
-  GoogleNetworkError,
-  insertCalendarEvent,
-  mapGoogleEvent,
-  toGoogleTime,
-} from "../../lib/google";
+import { ProviderError } from "../../integrations/calendar/errors";
+import { getCalendarAdapter } from "../../integrations/calendar/registry";
+import { createEventReconciling } from "../../integrations/calendar/service";
+import { providerEventToMapped } from "../../integrations/google/mappers";
 
 export async function acceptBookingHandler(
   ctx: ActionCtx,
@@ -33,7 +29,9 @@ export async function acceptBookingHandler(
     throw new Error("Not authenticated");
   }
 
-  const accessToken = await getGoogleAccessToken(ctx, user._id);
+  // Resolve the adapter (the credential broker resolves the token inside it)
+  // before claiming, so a missing/invalid grant fails fast without taking a lease.
+  const adapter = await getCalendarAdapter(ctx, user._id);
 
   const calendarId =
     (await ctx.runQuery(internal.calendar.getPrimaryCalendarId, {
@@ -65,42 +63,30 @@ export async function acceptBookingHandler(
   } = claimed;
 
   const label = page.title?.trim() || "Meeting";
-  const requestedGoogleEventId = googleEventIdForOperation(operationId);
   let event;
   try {
-    try {
-      event = await insertCalendarEvent(
-        accessToken,
-        claimedCalendarId,
-        {
-          id: requestedGoogleEventId,
-          summary: `${label} with ${booking.requesterName}`,
-          description: booking.note
-            ? `Booked via qali.\n\n${booking.note}`
-            : "Booked via qali.",
-          start: toGoogleTime(booking.startMs, false, page.timeZone),
-          end: toGoogleTime(booking.endMs, false, page.timeZone),
-          attendees: [
-            {
-              email: booking.requesterEmail,
-              displayName: booking.requesterName,
-            },
-          ],
-        },
-        // Google owns the invitation email; this is what sends it.
-        "all",
-      );
-    } catch (error) {
-      if (!(error instanceof GoogleApiError) || error.status !== 409) throw error;
-      event = mapGoogleEvent(
-        await getCalendarEvent(
-          accessToken,
-          claimedCalendarId,
-          requestedGoogleEventId,
-        ),
-        claimedCalendarId,
-      );
-    }
+    // The operationId is the idempotency key: a retry that already created the
+    // event reconciles instead of double-booking (adapter maps it to Google's
+    // client-assigned event id + 409-as-success).
+    const providerEvent = await createEventReconciling(adapter, {
+      calendarId: claimedCalendarId,
+      event: {
+        summary: `${label} with ${booking.requesterName}`,
+        description: booking.note
+          ? `Booked via qali.\n\n${booking.note}`
+          : "Booked via qali.",
+        startMs: booking.startMs,
+        endMs: booking.endMs,
+        allDay: false,
+        timeZone: page.timeZone,
+        attendees: [
+          { email: booking.requesterEmail, displayName: booking.requesterName },
+        ],
+      },
+      idempotencyKey: operationId,
+      notify: "all",
+    });
+    event = providerEventToMapped(providerEvent);
 
     const marked = await ctx.runMutation(internal.booking.markAccepted, {
       bookingId: args.bookingId,
@@ -115,8 +101,11 @@ export async function acceptBookingHandler(
       bookingId: args.bookingId,
       hostUserId: user._id,
       attemptId,
+      // An ambiguous provider failure (a lost response) is the "may have landed"
+      // case — the neutral successor to the old GoogleNetworkError branch.
       mayHaveSucceeded:
-        event !== undefined || error instanceof GoogleNetworkError,
+        event !== undefined ||
+        (error instanceof ProviderError && error.kind === "ambiguous"),
     });
     if (event) {
       throw new Error(
@@ -126,15 +115,15 @@ export async function acceptBookingHandler(
     throw error;
   }
 
-  // The booking state and Google event are authoritative. A sync repairs this
-  // optional optimistic mirror if the local write is transiently unavailable.
+  // The booking state and the provider event are authoritative. A sync repairs
+  // this optional optimistic mirror if the local write is transiently unavailable.
   try {
     await ctx.runMutation(internal.calendar.upsertEvent, {
       userId: user._id,
       event,
     });
   } catch (error) {
-    console.error("[booking] Google accepted event; mirror pending", error);
+    console.error("[booking] provider accepted event; mirror pending", error);
   }
   return null;
 }

--- a/packages/backend/convex/domains/calendar/connections.ts
+++ b/packages/backend/convex/domains/calendar/connections.ts
@@ -1,0 +1,33 @@
+import type { Id } from "../../_generated/dataModel";
+import type { MutationCtx } from "../../_generated/server";
+
+/**
+ * Find (or lazily create) the user's single Google calendar connection.
+ *
+ * Connection == the login grant in v1, so the credential is still resolved
+ * through Better Auth — this row only carries the neutral provider identity and
+ * capabilities. Reused by the backfill and every dual-write path, so a user the
+ * backfill missed (or who signed up since) still gets a connection on their next
+ * write or sync. Idempotent: one Google connection per user.
+ */
+export async function ensureGoogleConnection(
+  ctx: MutationCtx,
+  userId: string,
+): Promise<Id<"calendarConnections">> {
+  const existing = await ctx.db
+    .query("calendarConnections")
+    .withIndex("by_user_and_provider", (q) =>
+      q.eq("userId", userId).eq("provider", "google"),
+    )
+    .first();
+  if (existing) return existing._id;
+  const now = Date.now();
+  return await ctx.db.insert("calendarConnections", {
+    userId,
+    provider: "google",
+    status: "active",
+    capabilities: { contacts: true, idempotentCreate: true },
+    createdAt: now,
+    updatedAt: now,
+  });
+}

--- a/packages/backend/convex/domains/calendar/dualWrite.itest.ts
+++ b/packages/backend/convex/domains/calendar/dualWrite.itest.ts
@@ -99,3 +99,41 @@ describe("calendar dual-write", () => {
     expect(series?.providerEventId).toBe("series-1");
   });
 });
+
+describe("sync engine dual-write", () => {
+  test("reconcile + upsertEventsPage + setSyncToken stamp the neutral mirror", async () => {
+    const t = convexTest(schema, modules);
+
+    await t.mutation(internal.googleSync.reconcileCalendars, {
+      userId: USER,
+      calendars: [{ googleCalendarId: "primary", primary: true }],
+    });
+    await t.mutation(internal.googleSync.upsertEventsPage, {
+      userId: USER,
+      events: [googleEvent],
+    });
+    await t.mutation(internal.googleSync.setCalendarSyncToken, {
+      userId: USER,
+      googleCalendarId: "primary",
+      syncToken: "tok-1",
+    });
+
+    await t.run(async (ctx) => {
+      const cal = await ctx.db
+        .query("calendars")
+        .withIndex("by_user", (q) => q.eq("userId", USER))
+        .unique();
+      expect(cal?.connectionId).toBeDefined();
+      expect(cal?.providerCalendarId).toBe("primary");
+      expect(cal?.syncCursor).toBe("tok-1"); // mirrors syncToken
+
+      const event = await ctx.db
+        .query("events")
+        .withIndex("by_user_and_start", (q) => q.eq("userId", USER))
+        .unique();
+      expect(event?.connectionId).toBe(cal?.connectionId);
+      expect(event?.providerEventId).toBe("g-evt");
+      expect(event?.providerUpdatedMs).toBe(777);
+    });
+  });
+});

--- a/packages/backend/convex/domains/calendar/dualWrite.itest.ts
+++ b/packages/backend/convex/domains/calendar/dualWrite.itest.ts
@@ -1,0 +1,101 @@
+/// <reference types="vite/client" />
+import { convexTest } from "convex-test";
+import { describe, expect, test } from "vitest";
+
+import { internal } from "../../_generated/api";
+import schema from "../../schema";
+
+const modules = import.meta.glob("../../**/*.ts");
+
+const USER = "user_dw";
+
+const googleEvent = {
+  googleEventId: "g-evt",
+  calendarId: "primary",
+  startMs: 1_000,
+  endMs: 2_000,
+  allDay: false,
+  status: "confirmed",
+  googleUpdatedMs: 777,
+};
+
+describe("calendar dual-write", () => {
+  test("upsertEvent stamps the neutral mirror and lazily creates the connection", async () => {
+    const t = convexTest(schema, modules);
+
+    await t.mutation(internal.calendar.upsertEvent, {
+      userId: USER,
+      event: googleEvent,
+    });
+
+    const { event, connectionCount, connectionId } = await t.run(async (ctx) => {
+      const event = await ctx.db
+        .query("events")
+        .withIndex("by_user_and_start", (q) => q.eq("userId", USER))
+        .unique();
+      const connections = await ctx.db
+        .query("calendarConnections")
+        .withIndex("by_user_and_provider", (q) =>
+          q.eq("userId", USER).eq("provider", "google"),
+        )
+        .collect();
+      return {
+        event,
+        connectionCount: connections.length,
+        connectionId: connections[0]?._id,
+      };
+    });
+
+    // A connection was created on demand (backfill may have missed this user).
+    expect(connectionCount).toBe(1);
+    // Neutral fields mirror the Google-named ones; legacy columns untouched.
+    expect(event?.connectionId).toBe(connectionId);
+    expect(event?.providerEventId).toBe("g-evt");
+    expect(event?.providerUpdatedMs).toBe(777);
+    expect(event?.googleEventId).toBe("g-evt");
+  });
+
+  test("a second upsert reuses the same connection (idempotent)", async () => {
+    const t = convexTest(schema, modules);
+    await t.mutation(internal.calendar.upsertEvent, {
+      userId: USER,
+      event: googleEvent,
+    });
+    await t.mutation(internal.calendar.upsertEvent, {
+      userId: USER,
+      event: { ...googleEvent, summary: "updated" },
+    });
+
+    const connections = await t.run((ctx) =>
+      ctx.db
+        .query("calendarConnections")
+        .withIndex("by_user_and_provider", (q) =>
+          q.eq("userId", USER).eq("provider", "google"),
+        )
+        .collect(),
+    );
+    expect(connections).toHaveLength(1);
+  });
+
+  test("upsertRecurringSeries stamps connectionId + providerEventId", async () => {
+    const t = convexTest(schema, modules);
+    await t.mutation(internal.calendar.upsertRecurringSeries, {
+      userId: USER,
+      calendarId: "primary",
+      googleEventId: "series-1",
+      recurrence: ["RRULE:FREQ=WEEKLY"],
+      sourceUpdatedMs: 5,
+    });
+
+    const series = await t.run((ctx) =>
+      ctx.db
+        .query("recurringSeries")
+        .withIndex("by_user_and_calendar_and_googleEventId", (q) =>
+          q.eq("userId", USER),
+        )
+        .unique(),
+    );
+    expect(series?.connectionId).toBeDefined();
+    expect(series?.providerEventId).toBe("series-1");
+  });
+});

--- a/packages/backend/convex/domains/calendar/mutations.ts
+++ b/packages/backend/convex/domains/calendar/mutations.ts
@@ -7,6 +7,7 @@ import type { Infer } from "convex/values";
 import type { Id } from "../../_generated/dataModel";
 import type { MutationCtx } from "../../_generated/server";
 import { authComponent } from "../../auth";
+import { ensureGoogleConnection } from "./connections";
 import { googleEventValidator } from "./validators";
 
 /** Toggle whether a calendar's events appear on the grid. */
@@ -61,6 +62,16 @@ export async function upsertEventHandler(
   ctx: MutationCtx,
   args: { userId: string; event: Infer<typeof googleEventValidator> },
 ): Promise<null> {
+  // Dual-write: stamp the neutral mirror alongside the Google-named columns so
+  // the row stays cutover-ready. Legacy columns remain the source of truth.
+  const connectionId = await ensureGoogleConnection(ctx, args.userId);
+  const doc = {
+    userId: args.userId,
+    ...args.event,
+    connectionId,
+    providerEventId: args.event.googleEventId,
+    providerUpdatedMs: args.event.googleUpdatedMs,
+  };
   const existing = await ctx.db
     .query("events")
     .withIndex("by_user_and_calendar_and_googleEventId", (q) =>
@@ -71,9 +82,9 @@ export async function upsertEventHandler(
     )
     .unique();
   if (existing) {
-    await ctx.db.replace(existing._id, { userId: args.userId, ...args.event });
+    await ctx.db.replace(existing._id, doc);
   } else {
-    await ctx.db.insert("events", { userId: args.userId, ...args.event });
+    await ctx.db.insert("events", doc);
   }
   return null;
 }
@@ -99,9 +110,14 @@ export async function upsertRecurringSeriesHandler(
         .eq("googleEventId", args.googleEventId),
     )
     .unique();
+  // Dual-write the neutral mirror (connectionId + providerEventId) on both the
+  // patch and insert paths, so incremental cache refreshes keep it current too.
+  const connectionId = await ensureGoogleConnection(ctx, args.userId);
   const value = {
     recurrence: args.recurrence,
     sourceUpdatedMs: args.sourceUpdatedMs,
+    connectionId,
+    providerEventId: args.googleEventId,
   };
   if (existing) {
     await ctx.db.patch(existing._id, value);

--- a/packages/backend/convex/domains/sync/engine.ts
+++ b/packages/backend/convex/domains/sync/engine.ts
@@ -20,6 +20,7 @@ import {
   fetchOtherContactsPage,
   SyncTokenExpiredError,
 } from "../../lib/google";
+import { ensureGoogleConnection } from "../calendar/connections";
 import { googleEventValidator } from "../calendar/validators";
 
 // Validators for data pushed from actions into mutations (mapped Google shapes).
@@ -1090,6 +1091,8 @@ export const reconcileCalendars = internalMutation({
     ctx,
     args,
   ): Promise<{ googleCalendarId: string; syncToken?: string }[]> => {
+    // Dual-write: newly discovered calendars carry the neutral mirror too.
+    const connectionId = await ensureGoogleConnection(ctx, args.userId);
     const existingCalendars = await ctx.db
       .query("calendars")
       .withIndex("by_user", (q) => q.eq("userId", args.userId))
@@ -1130,6 +1133,8 @@ export const reconcileCalendars = internalMutation({
           userId: args.userId,
           selected: cal.googleSelected ?? false,
           ...cal,
+          connectionId,
+          providerCalendarId: cal.googleCalendarId,
         });
         stored.push({ googleCalendarId: cal.googleCalendarId });
       }
@@ -1274,7 +1279,11 @@ export const commitCalendarFullResync = internalMutation({
       await ctx.db.patch(row._id, {
         syncGeneration: args.syncGeneration,
         ...(args.syncToken !== undefined
-          ? { syncToken: args.syncToken, lastSyncAt: Date.now() }
+          ? {
+              syncToken: args.syncToken,
+              syncCursor: args.syncToken, // neutral mirror
+              lastSyncAt: Date.now(),
+            }
           : {}),
       });
     }
@@ -1298,6 +1307,7 @@ export const setCalendarSyncToken = internalMutation({
     if (row) {
       await ctx.db.patch(row._id, {
         syncToken: args.syncToken,
+        syncCursor: args.syncToken, // neutral mirror
         lastSyncAt: Date.now(),
       });
     }
@@ -1596,6 +1606,9 @@ export const upsertEventsPage = internalMutation({
     syncGeneration: v.optional(v.number()),
   },
   handler: async (ctx, args): Promise<null> => {
+    // Dual-write: resolve the connection once per page, then stamp the neutral
+    // mirror on every synced row alongside the Google-named columns.
+    const connectionId = await ensureGoogleConnection(ctx, args.userId);
     const harvested: PersonInput[] = [];
     for (const e of args.events) {
       const existing = await ctx.db
@@ -1613,20 +1626,20 @@ export const upsertEventsPage = internalMutation({
         }
         continue;
       }
+      const doc = {
+        userId: args.userId,
+        ...e,
+        syncGeneration: args.syncGeneration,
+        connectionId,
+        providerEventId: e.googleEventId,
+        providerUpdatedMs: e.googleUpdatedMs,
+      };
       if (existing) {
         // A mapped Google event is an authoritative snapshot. Replacing the row
         // also clears optional fields that Google removed from the event.
-        await ctx.db.replace(existing._id, {
-          userId: args.userId,
-          ...e,
-          syncGeneration: args.syncGeneration,
-        });
+        await ctx.db.replace(existing._id, doc);
       } else {
-        await ctx.db.insert("events", {
-          userId: args.userId,
-          ...e,
-          syncGeneration: args.syncGeneration,
-        });
+        await ctx.db.insert("events", doc);
       }
       harvested.push(...collectEventPeople(e));
     }

--- a/packages/backend/convex/integrations/google/mappers.test.ts
+++ b/packages/backend/convex/integrations/google/mappers.test.ts
@@ -10,6 +10,7 @@ import {
 import {
   decodeCursor,
   encodeCursor,
+  providerEventToMapped,
   toProviderError,
   toProviderEvent,
 } from "./mappers";
@@ -69,6 +70,47 @@ describe("toProviderEvent", () => {
     expect(toProviderEvent(mappedEvent({ status: "cancelled" })).status).toBe(
       "cancelled",
     );
+  });
+});
+
+describe("providerEventToMapped (reverse map)", () => {
+  test("round-trips a mapped event through the neutral shape and back", () => {
+    const original = mappedEvent({
+      summary: "Sync",
+      description: "notes",
+      location: "Room 1",
+      transparency: "transparent",
+      colorId: "5",
+      recurringEventId: "series-9",
+      conferenceUrl: "https://meet.example/xyz",
+      conferenceType: "hangoutsMeet",
+      attendees: [
+        { email: "me@x.com", self: true, responseStatus: "accepted" },
+        { email: "guest@x.com", optional: true },
+      ],
+      guestsCanModify: false,
+    });
+
+    const back = providerEventToMapped(toProviderEvent(original));
+
+    expect(back.googleEventId).toBe("g-evt");
+    expect(back.googleUpdatedMs).toBe(500);
+    expect(back.transparency).toBe("transparent");
+    expect(back.colorId).toBe("5");
+    expect(back.recurringEventId).toBe("series-9");
+    expect(back.conferenceUrl).toBe("https://meet.example/xyz");
+    expect(back.hangoutLink).toBe("https://meet.example/xyz"); // hangoutsMeet
+    expect(back.attendees).toEqual(original.attendees);
+    expect(back.summary).toBe("Sync");
+  });
+
+  test("busy/transparency mapping survives the round trip", () => {
+    // Absent transparency stays absent (Google's busy default), not invented.
+    expect(providerEventToMapped(toProviderEvent(mappedEvent())).transparency).toBeUndefined();
+    expect(
+      providerEventToMapped(toProviderEvent(mappedEvent({ transparency: "opaque" })))
+        .transparency,
+    ).toBe("opaque");
   });
 });
 

--- a/packages/backend/convex/integrations/google/mappers.ts
+++ b/packages/backend/convex/integrations/google/mappers.ts
@@ -104,6 +104,58 @@ export function toProviderEvent(event: MappedEvent): ProviderEvent {
   };
 }
 
+/**
+ * Reverse of {@link toProviderEvent}: a neutral event back into the Google-shaped
+ * `MappedEvent` the synced `events` table stores. Used at cutover so a write that
+ * goes through the adapter (which returns a ProviderEvent) can still be mirrored
+ * into the row shape the rest of the app reads. For Google the id round-trips
+ * exactly (`id` is the `googleEventId`); the neutral `busy` flag becomes
+ * `transparency`, and `conference` unfolds back into the flat conference fields.
+ */
+export function providerEventToMapped(event: ProviderEvent): MappedEvent {
+  return {
+    googleEventId: event.id,
+    calendarId: event.calendarId,
+    summary: event.summary,
+    description: event.description,
+    location: event.location,
+    startMs: event.startMs,
+    endMs: event.endMs,
+    allDay: event.allDay,
+    status: event.status,
+    htmlLink: event.htmlLink,
+    colorId: event.color,
+    visibility: event.visibility,
+    transparency:
+      event.busy === undefined ? undefined : event.busy ? "opaque" : "transparent",
+    attendees: event.attendees
+      ?.filter((a): a is typeof a & { email: string } => a.email !== undefined)
+      .map((a) => ({
+        email: a.email,
+        displayName: a.displayName,
+        responseStatus: a.responseStatus,
+        organizer: a.organizer,
+        self: a.self,
+        optional: a.optional,
+      })),
+    attendeesOmitted: event.attendeesOmitted,
+    googleUpdatedMs: event.updatedMs,
+    organizer: event.organizer,
+    creator: event.creator,
+    guestsCanModify: event.guestsCanModify,
+    guestsCanInviteOthers: event.guestsCanInviteOthers,
+    guestsCanSeeOtherGuests: event.guestsCanSeeOtherGuests,
+    locked: event.locked,
+    eventType: event.eventType,
+    recurringEventId: event.seriesId,
+    hangoutLink:
+      event.conference?.type === "hangoutsMeet" ? event.conference.url : undefined,
+    conferenceUrl: event.conference?.url,
+    conferenceName: event.conference?.name,
+    conferenceType: event.conference?.type,
+  };
+}
+
 // --- Opaque cursor codec ---------------------------------------------------
 // Google exposes two distinct cursors — a `pageToken` that walks within one
 // sync pass and a `syncToken` that deltas between passes. The port hides both


### PR DESCRIPTION
This pull request introduces several improvements to the calendar event layout logic and booking data consistency. The most significant changes focus on enhancing the visual clarity of overlapping events in the calendar UI by introducing a tiling rule for closely-starting events, making the layout more readable. Additionally, the backend now ensures consistent dual-writing of booking provider information for both new and backfilled bookings.

**Calendar Event Layout Improvements:**

- Added a tiling rule to the `layoutDayEvents` function: when overlapping events start within a configurable short time window, they are laid out in non-overlapping columns ("tiled") instead of the usual overlapping "fan" style, improving readability. This threshold is configurable for day and week views. (`apps/web/src/components/calendar/lib.ts`, `apps/web/src/components/calendar/day-column.tsx`) [[1]](diffhunk://#diff-d5c5e1bad0bff4fc6609cc2dcca91ba726bbf1890cf917e354694265dafac4dfR555-R587) [[2]](diffhunk://#diff-d5c5e1bad0bff4fc6609cc2dcca91ba726bbf1890cf917e354694265dafac4dfR601) [[3]](diffhunk://#diff-d5c5e1bad0bff4fc6609cc2dcca91ba726bbf1890cf917e354694265dafac4dfR658-R679) [[4]](diffhunk://#diff-e7f077cd44e931a2c9523c240908d15eea76efe3da3af9b10c84a5ce4f617e8aR108-R116)
- Updated the `PositionedEvent` type and `laneBox` function to support the new tiling logic, including a new `laneAdvance` property that determines the overlap or tiling of events. (`apps/web/src/components/calendar/lib.ts`, `apps/web/src/components/calendar/event-card.tsx`) [[1]](diffhunk://#diff-d5c5e1bad0bff4fc6609cc2dcca91ba726bbf1890cf917e354694265dafac4dfR520-R533) [[2]](diffhunk://#diff-81f404d1ac0eb50c36f15639000a7eedaccb2df484dd0ce22beaac397515c56eL47-R94)
- Adjusted the event card UI to reserve a gutter on the left edge, ensuring that no event card covers the column's border and improving drag-create usability. (`apps/web/src/components/calendar/lib.ts`, `apps/web/src/components/calendar/event-card.tsx`) [[1]](diffhunk://#diff-d5c5e1bad0bff4fc6609cc2dcca91ba726bbf1890cf917e354694265dafac4dfR520-R533) [[2]](diffhunk://#diff-81f404d1ac0eb50c36f15639000a7eedaccb2df484dd0ce22beaac397515c56eL47-R94)

**Testing Enhancements:**

- Added comprehensive tests for the new overlap tiling logic, verifying that events tile or fan as expected under various scenarios and thresholds. (`apps/web/src/components/calendar/lib.test.ts`) [[1]](diffhunk://#diff-e67b0da052439aa078ab296d0c3f30f27daac5f764f9672e2a718ec6a38934f0R352-R440) [[2]](diffhunk://#diff-e67b0da052439aa078ab296d0c3f30f27daac5f764f9672e2a718ec6a38934f0R458-R467)

**Booking Backend Consistency:**

- Refactored backend booking mutations to dual-write the provider event ID and connection ID for both new and backfilled bookings, ensuring data consistency and simplifying future provider support. (`packages/backend/convex/domains/booking/mutations.ts`, `packages/backend/convex/backfillConnections.ts`, `packages/backend/convex/booking.itest.ts`) [[1]](diffhunk://#diff-86a27072330f99ba4728af7708e602ee93b9797daca9876a249701359492d355R217-R219) [[2]](diffhunk://#diff-86a27072330f99ba4728af7708e602ee93b9797daca9876a249701359492d355R230) [[3]](diffhunk://#diff-86a27072330f99ba4728af7708e602ee93b9797daca9876a249701359492d355R318-R325) [[4]](diffhunk://#diff-c3ff3b32c02063e50d3e8d50d9132f371b8e5ab86adfde88b1d2366b737a8608L115-R93) [[5]](diffhunk://#diff-916c8ae46725b3e802efba3a5f65603324211bf90867ffeb42fe20d037441195R247-R249)

These changes collectively improve both the user experience in the calendar UI and the robustness of booking data in the backend.