### PR TITLE
Add privacy and terms pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # qali
 
-A fast, keyboard-friendly calendar client for Google Calendar. qali syncs your
+An AI-native calendar for Google Calendar. qali syncs your
 Google calendars and builds a unified people directory from your saved contacts,
 Google's auto-collected "Other contacts", and everyone you meet with on your
 calendar — so guests show a real name and avatar even when you never saved them.

--- a/apps/www/src/components/legal-page.tsx
+++ b/apps/www/src/components/legal-page.tsx
@@ -1,0 +1,83 @@
+import { Link } from "@tanstack/react-router";
+import type { ReactNode } from "react";
+
+/** Shared chrome for the /privacy and /terms pages: the qali wordmark, a
+ * readable measure, and consistent heading rhythm. Content is passed as
+ * children so each policy owns its own copy. */
+export function LegalPage({
+  title,
+  updated,
+  children,
+}: {
+  title: string;
+  updated: string;
+  children: ReactNode;
+}) {
+  return (
+    <main className="min-h-svh bg-background text-foreground">
+      <article className="legal-prose mx-auto max-w-3xl px-6 py-12 sm:py-16">
+        <Link
+          to="/"
+          className="inline-flex items-center gap-2 text-sm font-medium text-muted-foreground transition-colors hover:text-foreground"
+        >
+          <svg
+            viewBox="0 0 24 24"
+            className="size-4"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={2}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden
+            focusable="false"
+          >
+            <path d="M19 12H5" />
+            <path d="m12 19-7-7 7-7" />
+          </svg>
+          Back
+        </Link>
+
+        <h1 className="mt-8 font-display text-3xl font-medium tracking-tight sm:text-4xl">
+          {title}
+        </h1>
+        <p className="mt-2 text-sm text-muted-foreground">Last updated {updated}</p>
+        <div className="mt-10 space-y-8 text-[15px] leading-relaxed text-muted-foreground">
+          {children}
+        </div>
+      </article>
+
+      <footer className="border-t border-border/50 px-6 py-10">
+        <div className="mx-auto flex max-w-3xl flex-col items-center gap-3 text-center text-sm text-muted-foreground sm:flex-row sm:justify-between sm:text-left">
+          <nav className="flex items-center gap-6">
+            <Link to="/privacy" className="transition-colors hover:text-foreground">
+              Privacy
+            </Link>
+            <Link to="/terms" className="transition-colors hover:text-foreground">
+              Terms
+            </Link>
+          </nav>
+          <span>© {new Date().getFullYear()} qali</span>
+        </div>
+      </footer>
+    </main>
+  );
+}
+
+/** A titled section within a policy. Headings share one style so the two
+ * documents read as a set. */
+export function LegalSection({
+  heading,
+  children,
+}: {
+  heading: string;
+  children: ReactNode;
+}) {
+  return (
+    <section className="space-y-3">
+      <h2 className="font-display text-xl font-medium tracking-tight text-foreground">
+        {heading}
+      </h2>
+      {children}
+    </section>
+  );
+}

--- a/apps/www/src/components/mascot.tsx
+++ b/apps/www/src/components/mascot.tsx
@@ -129,12 +129,6 @@ export function Mascot({ className, proximity = 220 }: MascotProps) {
   const tapScaleY = useMotionValue(1);
   const tapAnimations = useRef<Array<{ stop: () => void }>>([]);
 
-  // On tap the capsule eyes scrunch into a happy `>  <` squint for a beat.
-  const [happy, setHappy] = useState(false);
-  const happyTimeout = useRef<ReturnType<typeof setTimeout> | undefined>(
-    undefined,
-  );
-
   const pointerActiveRef = useRef(false);
 
   const resetPointer = useCallback(() => {
@@ -171,8 +165,6 @@ export function Mascot({ className, proximity = 220 }: MascotProps) {
     tapAnimations.current = [];
     tapScaleX.set(1);
     tapScaleY.set(1);
-    clearTimeout(happyTimeout.current);
-    setHappy(false);
   }, [paused, resetPointer, tapScaleX, tapScaleY]);
 
   useEffect(() => {
@@ -281,16 +273,12 @@ export function Mascot({ className, proximity = 220 }: MascotProps) {
   useEffect(
     () => () => {
       tapAnimations.current.forEach((animation) => animation.stop());
-      clearTimeout(happyTimeout.current);
     },
     [],
   );
 
   const reactToTap = useCallback(() => {
     if (paused) return;
-    setHappy(true);
-    clearTimeout(happyTimeout.current);
-    happyTimeout.current = setTimeout(() => setHappy(false), 1300);
     tapAnimations.current.forEach((animation) => animation.stop());
     tapAnimations.current = [
       animate(tapScaleX, [tapScaleX.get(), 1.085, 0.98, 1], {
@@ -465,13 +453,8 @@ export function Mascot({ className, proximity = 220 }: MascotProps) {
                     style={{ x: pupilX, y: pupilY }}
                     filter={`url(#${eyeShadowId})`}
                   >
-                    {/* Resting capsule eyes — fade out when the scrunch fires. */}
-                    <g
-                      style={{
-                        opacity: happy ? 0 : 1,
-                        transition: "opacity 0.16s ease-out",
-                      }}
-                    >
+                    {/* Resting capsule eyes. */}
+                    <g>
                       <g>
                         <rect
                           x="79"
@@ -508,21 +491,6 @@ export function Mascot({ className, proximity = 220 }: MascotProps) {
                           fill={`url(#${eyeGlossId})`}
                         />
                       </g>
-                    </g>
-                    {/* Happy `>  <` squint — a scrunch reaction to being poked. */}
-                    <g
-                      fill="none"
-                      stroke={`url(#${eyeChromaId})`}
-                      strokeWidth="13"
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      style={{
-                        opacity: happy ? 1 : 0,
-                        transition: "opacity 0.16s ease-out",
-                      }}
-                    >
-                      <path d="M85 92 L106 114 L85 136" />
-                      <path d="M151 96 L130 118 L151 140" />
                     </g>
                   </motion.g>
                 </g>

--- a/apps/www/src/index.css
+++ b/apps/www/src/index.css
@@ -357,3 +357,30 @@
     opacity: 0;
   }
 }
+
+/* --- Legal pages (/privacy, /terms) --------------------------------------
+ * A light prose layer scoped to the policy documents. The surrounding layout
+ * sets the base text color; these rules only handle inline elements so the
+ * copy can be written as plain markup. */
+.legal-prose a {
+  color: var(--foreground);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+.legal-prose a:hover {
+  opacity: 0.75;
+}
+.legal-prose strong {
+  color: var(--foreground);
+  font-weight: 600;
+}
+.legal-prose ul {
+  list-style: disc;
+  padding-left: 1.25rem;
+}
+.legal-prose ul li {
+  margin-top: 0.4rem;
+}
+.legal-prose ul li::marker {
+  color: color-mix(in oklab, var(--muted-foreground) 60%, transparent);
+}

--- a/apps/www/src/routeTree.gen.ts
+++ b/apps/www/src/routeTree.gen.ts
@@ -9,8 +9,20 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
+import { Route as TermsRouteImport } from './routes/terms'
+import { Route as PrivacyRouteImport } from './routes/privacy'
 import { Route as IndexRouteImport } from './routes/index'
 
+const TermsRoute = TermsRouteImport.update({
+  id: '/terms',
+  path: '/terms',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const PrivacyRoute = PrivacyRouteImport.update({
+  id: '/privacy',
+  path: '/privacy',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
@@ -19,28 +31,50 @@ const IndexRoute = IndexRouteImport.update({
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
+  '/privacy': typeof PrivacyRoute
+  '/terms': typeof TermsRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/privacy': typeof PrivacyRoute
+  '/terms': typeof TermsRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
+  '/privacy': typeof PrivacyRoute
+  '/terms': typeof TermsRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/'
+  fullPaths: '/' | '/privacy' | '/terms'
   fileRoutesByTo: FileRoutesByTo
-  to: '/'
-  id: '__root__' | '/'
+  to: '/' | '/privacy' | '/terms'
+  id: '__root__' | '/' | '/privacy' | '/terms'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
+  PrivacyRoute: typeof PrivacyRoute
+  TermsRoute: typeof TermsRoute
 }
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
+    '/terms': {
+      id: '/terms'
+      path: '/terms'
+      fullPath: '/terms'
+      preLoaderRoute: typeof TermsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/privacy': {
+      id: '/privacy'
+      path: '/privacy'
+      fullPath: '/privacy'
+      preLoaderRoute: typeof PrivacyRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/': {
       id: '/'
       path: '/'
@@ -53,6 +87,8 @@ declare module '@tanstack/react-router' {
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
+  PrivacyRoute: PrivacyRoute,
+  TermsRoute: TermsRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/apps/www/src/routes/privacy.tsx
+++ b/apps/www/src/routes/privacy.tsx
@@ -33,7 +33,7 @@ function PrivacyPage() {
           qali is the data controller for the information described here. If you
           have any question about this policy or want to exercise your rights,
           contact us at{" "}
-          <a href="mailto:privacy@qali.app">privacy@qali.app</a>.
+          <a href="mailto:privacy@myqali.com">privacy@myqali.com</a>.
         </p>
       </LegalSection>
 
@@ -247,7 +247,7 @@ function PrivacyPage() {
         </ul>
         <p>
           To make any of these requests, email{" "}
-          <a href="mailto:privacy@qali.app">privacy@qali.app</a>.
+          <a href="mailto:privacy@myqali.com">privacy@myqali.com</a>.
         </p>
       </LegalSection>
 

--- a/apps/www/src/routes/privacy.tsx
+++ b/apps/www/src/routes/privacy.tsx
@@ -1,0 +1,271 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+import { LegalPage, LegalSection } from "@/components/legal-page";
+
+export const Route = createFileRoute("/privacy")({
+  component: PrivacyPage,
+  head: () => ({
+    meta: [
+      { title: "Privacy Policy — qali" },
+      {
+        name: "description",
+        content:
+          "How qali collects, uses, stores, and shares your Google Calendar and contacts data.",
+      },
+    ],
+  }),
+});
+
+function PrivacyPage() {
+  return (
+    <LegalPage title="Privacy Policy" updated="August 16, 2026">
+      <p>
+        qali (&ldquo;qali,&rdquo; &ldquo;we,&rdquo; &ldquo;us&rdquo;) is an
+        AI-native calendar for Google Calendar. This policy
+        explains what data we access when you connect your Google account, why
+        we access it, how long we keep it, and who we share it with. We designed
+        qali to hold as little as it needs to run the calendar you asked it to
+        run.
+      </p>
+
+      <LegalSection heading="Who we are">
+        <p>
+          qali is the data controller for the information described here. If you
+          have any question about this policy or want to exercise your rights,
+          contact us at{" "}
+          <a href="mailto:privacy@qali.app">privacy@qali.app</a>.
+        </p>
+      </LegalSection>
+
+      <LegalSection heading="Data we collect">
+        <p>
+          Almost everything qali holds comes from Google, with your permission,
+          at the moment you sign in and while the app is connected:
+        </p>
+        <ul>
+          <li>
+            <strong>Account identity.</strong> When you sign in with Google we
+            receive your name, email address, and profile picture (the standard
+            OpenID <em>email</em> and <em>profile</em> scopes). This identifies
+            your account and shows your avatar in the app.
+          </li>
+          <li>
+            <strong>Google Calendar.</strong> With the Google Calendar scope we
+            read and write your calendars and their events — event titles,
+            descriptions, times, locations, guests and their responses,
+            free/busy status, recurrence rules, and Google Meet links — so you
+            can view, create, edit, and reschedule events from qali.
+          </li>
+          <li>
+            <strong>Google Contacts.</strong> With the read-only Contacts scope
+            we read your saved contacts — names, email addresses, phone numbers,
+            and photos.
+          </li>
+          <li>
+            <strong>Google &ldquo;Other contacts.&rdquo;</strong> With the
+            read-only Other Contacts scope we read the addresses Google
+            auto-collects for people you have interacted with but never saved.
+            This is how guests show a real name and avatar even when they are
+            not in your contacts.
+          </li>
+          <li>
+            <strong>A people directory we build.</strong> From your calendar
+            guests and both contact sources, qali derives a unified,
+            email-keyed directory of the people you meet with. It includes
+            derived fields such as how many times and when you have met and a
+            relevance score used only to order results.
+          </li>
+          <li>
+            <strong>Booking pages.</strong> If you create a public booking page,
+            we store its settings and availability. When someone requests a
+            time, we store the name, email address, and any note they submit.
+          </li>
+          <li>
+            <strong>Assistant conversations.</strong> If you use the optional AI
+            scheduling assistant, we store your chat threads and the proposed
+            actions so the conversation persists between sessions.
+          </li>
+          <li>
+            <strong>Waitlist.</strong> If you join the waitlist on our website,
+            we store the email address you submit.
+          </li>
+          <li>
+            <strong>Operational logs.</strong> Our hosting providers keep
+            standard technical logs (such as timestamps and error traces) needed
+            to run, secure, and debug the service. qali does not use advertising
+            trackers or third-party analytics pixels on its website or app.
+          </li>
+        </ul>
+      </LegalSection>
+
+      <LegalSection heading="How we use your data">
+        <p>We use the data above only to provide and operate qali:</p>
+        <ul>
+          <li>
+            Sync and display your calendars and let you create, edit, and
+            reschedule events.
+          </li>
+          <li>
+            Build the people directory so guests show real names and avatars,
+            and so you can find people quickly.
+          </li>
+          <li>Run your public booking pages and notify you of requests.</li>
+          <li>
+            Power the optional AI scheduling assistant when you choose to use
+            it.
+          </li>
+          <li>Keep the service secure, reliable, and debuggable.</li>
+        </ul>
+        <p>
+          We do <strong>not</strong> sell your data, use it for advertising, or
+          use your Google Calendar or contacts data to train generalized AI or
+          machine-learning models.
+        </p>
+      </LegalSection>
+
+      <LegalSection heading="The AI scheduling assistant">
+        <p>
+          The AI assistant is optional and off unless you use it. When you send
+          it a message, qali sends the content needed to answer your request —
+          which can include relevant calendar events, people from your
+          directory, and pending booking requests — to our model provider,{" "}
+          <a href="https://www.deepseek.com" target="_blank" rel="noreferrer">
+            DeepSeek
+          </a>
+          , to generate a response. We send only what a given request needs, and
+          only when you actively use the assistant. If you never open it, none
+          of your data is sent to the model provider.
+        </p>
+      </LegalSection>
+
+      <LegalSection heading="Google API Limited Use disclosure">
+        <p>
+          qali&rsquo;s use of information received from Google APIs adheres to
+          the{" "}
+          <a
+            href="https://developers.google.com/terms/api-services-user-data-policy"
+            target="_blank"
+            rel="noreferrer"
+          >
+            Google API Services User Data Policy
+          </a>
+          , including its Limited Use requirements. We only use Google user data
+          to provide and improve the qali features you see, we do not transfer
+          it to others except as needed to provide those features (see below),
+          we do not use it for advertising, and no humans read your Google data
+          except where you explicitly ask us to, for security or to comply with
+          the law.
+        </p>
+      </LegalSection>
+
+      <LegalSection heading="Who we share it with">
+        <p>
+          We share data only with the service providers that make qali work,
+          each acting on our behalf under contract:
+        </p>
+        <ul>
+          <li>
+            <strong>Google</strong> — the source of your calendar and contacts
+            data, via the Google Calendar and People APIs.
+          </li>
+          <li>
+            <strong>Convex</strong> — our backend and database host, where your
+            qali data is stored.
+          </li>
+          <li>
+            <strong>Cloudflare</strong> — hosts our website and application.
+          </li>
+          <li>
+            <strong>DeepSeek</strong> — our AI model provider, which receives
+            request context only when you use the assistant (see above).
+          </li>
+        </ul>
+        <p>
+          We may also disclose data if required by law, or to protect the
+          rights, safety, and security of qali and its users. We do not sell
+          your personal information.
+        </p>
+      </LegalSection>
+
+      <LegalSection heading="How long we keep it">
+        <ul>
+          <li>
+            <strong>Calendar events</strong> are retained for about 180 days
+            around the current date; older events are removed from qali (they
+            remain in Google Calendar).
+          </li>
+          <li>
+            <strong>Assistant conversations</strong> are deleted after roughly
+            30 days of inactivity.
+          </li>
+          <li>
+            <strong>Contacts, the people directory, calendars, and booking
+            settings</strong>{" "}
+            are kept while your account is connected and refreshed as your
+            Google data changes.
+          </li>
+          <li>
+            When you disconnect or delete your account, we delete the data we
+            hold for you, except where we must keep limited records to comply
+            with the law.
+          </li>
+        </ul>
+      </LegalSection>
+
+      <LegalSection heading="Security and credentials">
+        <p>
+          qali signs you in through Google OAuth; we never see or store a Google
+          password. Access to your Google account is handled by access and
+          refresh tokens managed by our authentication layer, not stored in
+          plain text in application data. We use industry-standard measures to
+          protect data in transit and at rest, though no method is perfectly
+          secure.
+        </p>
+      </LegalSection>
+
+      <LegalSection heading="Your choices and rights">
+        <ul>
+          <li>
+            <strong>Revoke access at any time</strong> from your{" "}
+            <a
+              href="https://myaccount.google.com/permissions"
+              target="_blank"
+              rel="noreferrer"
+            >
+              Google Account permissions
+            </a>
+            . qali immediately loses access to your Google data.
+          </li>
+          <li>
+            <strong>Access, correct, or delete</strong> the data we hold, and
+            request a copy, by contacting us. Depending on where you live, you
+            may have these rights under laws such as the GDPR or CCPA.
+          </li>
+          <li>
+            <strong>Delete your account</strong> to have your qali data removed.
+          </li>
+        </ul>
+        <p>
+          To make any of these requests, email{" "}
+          <a href="mailto:privacy@qali.app">privacy@qali.app</a>.
+        </p>
+      </LegalSection>
+
+      <LegalSection heading="Children">
+        <p>
+          qali is not directed to children under 16, and we do not knowingly
+          collect their data.
+        </p>
+      </LegalSection>
+
+      <LegalSection heading="Changes to this policy">
+        <p>
+          We may update this policy as qali evolves. When we make material
+          changes, we will update the date above and, where appropriate, notify
+          you. Continued use of qali after a change means you accept the updated
+          policy.
+        </p>
+      </LegalSection>
+    </LegalPage>
+  );
+}

--- a/apps/www/src/routes/terms.tsx
+++ b/apps/www/src/routes/terms.tsx
@@ -170,7 +170,7 @@ function TermsPage() {
       <LegalSection heading="Contact">
         <p>
           Questions about these Terms? Email{" "}
-          <a href="mailto:support@qali.app">support@qali.app</a>.
+          <a href="mailto:support@myqali.com">support@myqali.com</a>.
         </p>
       </LegalSection>
     </LegalPage>

--- a/apps/www/src/routes/terms.tsx
+++ b/apps/www/src/routes/terms.tsx
@@ -1,0 +1,178 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+import { LegalPage, LegalSection } from "@/components/legal-page";
+
+export const Route = createFileRoute("/terms")({
+  component: TermsPage,
+  head: () => ({
+    meta: [
+      { title: "Terms of Service — qali" },
+      {
+        name: "description",
+        content: "The terms that govern your use of qali.",
+      },
+    ],
+  }),
+});
+
+function TermsPage() {
+  return (
+    <LegalPage title="Terms of Service" updated="August 16, 2026">
+      <p>
+        These Terms of Service (&ldquo;Terms&rdquo;) govern your use of qali, a
+        calendar client for Google Calendar. By signing in or otherwise using
+        qali, you agree to these Terms. If you do not agree, do not use qali.
+      </p>
+
+      <LegalSection heading="The service">
+        <p>
+          qali connects to your Google account to sync your calendars and
+          contacts, builds a unified people directory, and lets you view,
+          create, edit, and reschedule events. It also offers optional features
+          including public booking pages and an AI scheduling assistant. qali is
+          currently in beta, which means features may change, break, or be
+          removed, and availability is not guaranteed.
+        </p>
+      </LegalSection>
+
+      <LegalSection heading="Eligibility and your account">
+        <p>
+          You must be at least 16 years old and able to form a binding contract
+          to use qali. You access qali by signing in with a Google account you
+          are authorized to use, and you are responsible for activity that
+          happens through your account. You must keep your Google account secure;
+          qali relies on Google to authenticate you and never handles your
+          Google password.
+        </p>
+      </LegalSection>
+
+      <LegalSection heading="Google account connection">
+        <p>
+          To work, qali needs the Google permissions you grant at sign-in,
+          including read and write access to your Google Calendar and read-only
+          access to your contacts. You can revoke these permissions at any time
+          from your{" "}
+          <a
+            href="https://myaccount.google.com/permissions"
+            target="_blank"
+            rel="noreferrer"
+          >
+            Google Account permissions
+          </a>
+          , which will stop qali from functioning. Your use of Google&rsquo;s
+          services remains subject to Google&rsquo;s own terms.
+        </p>
+      </LegalSection>
+
+      <LegalSection heading="Acceptable use">
+        <p>You agree not to:</p>
+        <ul>
+          <li>Use qali to break the law or infringe anyone&rsquo;s rights.</li>
+          <li>
+            Access data, calendars, or accounts you are not authorized to
+            access.
+          </li>
+          <li>
+            Interfere with, overload, probe, or attempt to bypass the security
+            of the service or its providers.
+          </li>
+          <li>
+            Reverse engineer, scrape, or resell the service except as permitted
+            by law.
+          </li>
+          <li>
+            Use booking pages or the assistant to send spam or harass others.
+          </li>
+        </ul>
+      </LegalSection>
+
+      <LegalSection heading="Booking pages">
+        <p>
+          If you publish a booking page, you are responsible for its content and
+          for the accuracy of the availability you offer. People who request
+          time submit their name, email, and an optional note; you are
+          responsible for handling that information appropriately. We may apply
+          rate limits and other protections to keep booking pages from being
+          abused.
+        </p>
+      </LegalSection>
+
+      <LegalSection heading="The AI assistant">
+        <p>
+          The AI scheduling assistant is optional and generates suggestions and
+          proposed actions that can be wrong. Scheduling actions it proposes take
+          effect only after you confirm them, and you are responsible for
+          reviewing them before they apply to your calendar. When you use the
+          assistant, request context is processed by our model provider as
+          described in the{" "}
+          <a href="/privacy">Privacy Policy</a>.
+        </p>
+      </LegalSection>
+
+      <LegalSection heading="Your content">
+        <p>
+          Your calendars, events, contacts, and messages remain yours. You grant
+          qali only the permission needed to operate the service for you — to
+          store, process, sync, and display your data, and to carry out the
+          actions you request. We claim no ownership of your content.
+        </p>
+      </LegalSection>
+
+      <LegalSection heading="Availability and changes">
+        <p>
+          We may modify, suspend, or discontinue qali or any feature at any
+          time, and we may set or change limits on use. We aim to give notice of
+          significant changes where practical, but qali is provided on an ongoing,
+          best-effort basis, especially during beta.
+        </p>
+      </LegalSection>
+
+      <LegalSection heading="Disclaimers">
+        <p>
+          qali is provided &ldquo;as is&rdquo; and &ldquo;as available,&rdquo;
+          without warranties of any kind, whether express or implied, including
+          fitness for a particular purpose, merchantability, and
+          non-infringement. We do not warrant that qali will be uninterrupted,
+          error-free, or that it will always sync accurately with Google. You are
+          responsible for verifying important scheduling information.
+        </p>
+      </LegalSection>
+
+      <LegalSection heading="Limitation of liability">
+        <p>
+          To the maximum extent permitted by law, qali and its providers will
+          not be liable for any indirect, incidental, special, consequential, or
+          punitive damages, or for any loss of data, meetings, profits, or
+          goodwill, arising out of or related to your use of qali. Nothing in
+          these Terms limits liability that cannot be limited under applicable
+          law.
+        </p>
+      </LegalSection>
+
+      <LegalSection heading="Termination">
+        <p>
+          You may stop using qali at any time by disconnecting your Google
+          account or deleting your account. We may suspend or terminate your
+          access if you violate these Terms or if we discontinue the service. On
+          termination, we handle your data as described in the{" "}
+          <a href="/privacy">Privacy Policy</a>.
+        </p>
+      </LegalSection>
+
+      <LegalSection heading="Changes to these Terms">
+        <p>
+          We may update these Terms from time to time. When we make material
+          changes, we will update the date above. Continued use of qali after a
+          change means you accept the updated Terms.
+        </p>
+      </LegalSection>
+
+      <LegalSection heading="Contact">
+        <p>
+          Questions about these Terms? Email{" "}
+          <a href="mailto:support@qali.app">support@qali.app</a>.
+        </p>
+      </LegalSection>
+    </LegalPage>
+  );
+}


### PR DESCRIPTION
Create shared legal page components and scoped prose styling for new Privacy Policy and Terms of Service routes. Update branding to describe qali
as an AI-native calendar and remove mascot tap-state handling.