### PR TITLE
Calendar working time zone

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@convex-dev/better-auth": "catalog:",
+    "@date-fns/tz": "^1.5.0",
     "@hookform/resolvers": "^5.4.0",
     "@hugeicons/core-free-icons": "^4.2.2",
     "@hugeicons/react": "^1.1.9",

--- a/apps/web/src/components/calendar/booking-block.tsx
+++ b/apps/web/src/components/calendar/booking-block.tsx
@@ -41,7 +41,8 @@ export function BookingBlock({
 }) {
   const { use24h, timeZone } = usePreferences();
   const topPct = msToPct(Math.max(booking.startMs, dayStartMs), dayStartMs);
-  const bottomPct = msToPct(booking.endMs, dayStartMs);
+  // A booking can cross the day cut; clamp so it never renders past the grid.
+  const bottomPct = Math.min(100, msToPct(booking.endMs, dayStartMs));
   const compact =
     (booking.endMs - booking.startMs) / MS_PER_MINUTE < COMPACT_BELOW_MINUTES;
   const startLabel = format(zoned(booking.startMs, timeZone), timePattern(use24h));

--- a/apps/web/src/components/calendar/booking-block.tsx
+++ b/apps/web/src/components/calendar/booking-block.tsx
@@ -4,7 +4,7 @@ import { format } from "date-fns";
 import type { Booking } from "@/components/workspace/booking-request-panel";
 import { usePreferences } from "@/components/workspace/preferences-context";
 
-import { msToPct, MS_PER_MINUTE, timePattern } from "./lib";
+import { msToPct, MS_PER_MINUTE, timePattern, zoned } from "./lib";
 import { RevealFlash, type Reveal } from "./today-pulse";
 
 /**
@@ -39,12 +39,12 @@ export function BookingBlock({
   reveal: Reveal;
   onOpen: () => void;
 }) {
-  const { use24h } = usePreferences();
+  const { use24h, timeZone } = usePreferences();
   const topPct = msToPct(Math.max(booking.startMs, dayStartMs), dayStartMs);
   const bottomPct = msToPct(booking.endMs, dayStartMs);
   const compact =
     (booking.endMs - booking.startMs) / MS_PER_MINUTE < COMPACT_BELOW_MINUTES;
-  const startLabel = format(booking.startMs, timePattern(use24h));
+  const startLabel = format(zoned(booking.startMs, timeZone), timePattern(use24h));
 
   return (
     <button
@@ -54,7 +54,7 @@ export function BookingBlock({
       data-event
       onClick={onOpen}
       aria-label={`Request from ${booking.requesterName}, ${format(
-        booking.startMs,
+        zoned(booking.startMs, timeZone),
         `EEE d MMM ${timePattern(use24h)}`,
       )}`}
       className={cn(

--- a/apps/web/src/components/calendar/calendar.tsx
+++ b/apps/web/src/components/calendar/calendar.tsx
@@ -33,6 +33,8 @@ import {
   VIEW_COLUMNS,
   VIEW_NAV_DAYS,
   viewTitle,
+  zoned,
+  zonedNow,
 } from "./lib";
 import { MonthPanel } from "./month-panel";
 import { MonthPicker } from "./month-picker";
@@ -49,10 +51,13 @@ const VIEWS: CalendarView[] = ["day", "week", "month"];
 const NO_EVENTS: Doc<"events">[] = [];
 
 export function CalendarWeekView() {
-  const { weekStartsOn, defaultView } = usePreferences();
+  const { weekStartsOn, defaultView, timeZone } = usePreferences();
+  // The anchor is a working-zone TZDate; date-fns propagates its zone through
+  // every derivation (stripDays, pageDays, headers), so the whole grid cuts
+  // days in the working zone.
   const [view, setView] = useState<CalendarView>(defaultView);
   const [anchor, setAnchor] = useState(() =>
-    pageStart(defaultView, new Date(), weekStartsOn),
+    pageStart(defaultView, zonedNow(timeZone), weekStartsOn),
   );
   const [reveal, setReveal] = useState<Reveal>(NO_REVEAL);
   const pagerRef = useRef<CalendarPagerHandle>(null);
@@ -105,12 +110,12 @@ export function CalendarWeekView() {
   // reads this plus the events below to land on the next free slot.
   const { registerCreateSeed, registerReveal } = useDock();
   const focusDayMs = useMemo(() => {
-    const today = startOfDay(new Date());
+    const today = startOfDay(zonedNow(timeZone));
     const onPage = pageDays(view, anchor, weekStartsOn).some((day) =>
       isSameDay(day, today),
     );
     return (onPage ? today : startOfDay(anchor)).getTime();
-  }, [view, anchor, weekStartsOn]);
+  }, [view, anchor, weekStartsOn, timeZone]);
   useEffect(() => {
     registerCreateSeed({ dayStartMs: focusDayMs, events });
     return () => registerCreateSeed(null);
@@ -136,14 +141,16 @@ export function CalendarWeekView() {
     [view, weekStartsOn],
   );
 
-  // A week-start change re-cuts the visible page: the anchor was computed
-  // under the old week shape, so re-normalize it (a no-op for day/month).
-  // Deliberately keyed on the preference alone — `view` is read for
-  // normalization only, and re-running on view changes would fight
+  // A week-start or working-zone change re-cuts the visible page: the anchor
+  // was computed under the old week shape / zone, so re-derive it around the
+  // same instant. Deliberately keyed on the preferences alone — `view` is
+  // read for normalization only, and re-running on view changes would fight
   // switchView's own anchor updates.
   useEffect(() => {
-    setAnchor((current) => pageStart(view, current, weekStartsOn));
-  }, [weekStartsOn]);
+    setAnchor((current) =>
+      pageStart(view, zoned(current.getTime(), timeZone), weekStartsOn),
+    );
+  }, [weekStartsOn, timeZone]);
 
   // Settle handlers must keep a stable identity across renders: the scrollers
   // derive their recentering effect's dependencies from them, so an inline
@@ -268,9 +275,9 @@ export function CalendarWeekView() {
   // Today is just a reveal of today's date pill at the current-time line.
   const goToToday = () =>
     revealTarget({
-      date: new Date(),
+      date: zonedNow(timeZone),
       vertical: "now",
-      flashId: dayKey(new Date()),
+      flashId: dayKey(zonedNow(timeZone)),
     });
 
   // The panels reach for an item by its start time and reveal key. In month
@@ -282,7 +289,7 @@ export function CalendarWeekView() {
       bumpReveal(input.flashId);
       return;
     }
-    const date = new Date(input.startMs);
+    const date = zoned(input.startMs, timeZone);
     if (layout.mode === "month") {
       revealTarget({ date, vertical: null, flashId: dayKey(date) });
     } else {

--- a/apps/web/src/components/calendar/day-picker.tsx
+++ b/apps/web/src/components/calendar/day-picker.tsx
@@ -22,7 +22,7 @@ import {
 import { type ReactElement, useMemo, useState } from "react";
 
 import { usePreferences } from "@/components/workspace/preferences-context";
-import type { WeekStart } from "./lib";
+import { zoned, type WeekStart } from "./lib";
 
 /** Single-letter weekday headers, in the user's week order. */
 function weekdayLetters(weekStartsOn: WeekStart): string[] {
@@ -50,17 +50,19 @@ export function DayPicker({
   side = "bottom",
   children,
 }: DayPickerProps) {
-  const { weekStartsOn } = usePreferences();
+  const { weekStartsOn, timeZone } = usePreferences();
   const [open, setOpen] = useState(false);
+  // Working-zone dates throughout, so grid days and "today" agree with the
+  // calendar behind the popover.
   const [viewMonth, setViewMonth] = useState(() =>
-    startOfMonth(new Date(selectedMs)),
+    startOfMonth(zoned(selectedMs, timeZone)),
   );
 
   const gridStart = startOfWeek(startOfMonth(viewMonth), { weekStartsOn });
   const gridEnd = endOfWeek(endOfMonth(viewMonth), { weekStartsOn });
   const weekdays = useMemo(() => weekdayLetters(weekStartsOn), [weekStartsOn]);
   const days = eachDayOfInterval({ start: gridStart, end: gridEnd });
-  const selectedDate = new Date(selectedMs);
+  const selectedDate = zoned(selectedMs, timeZone);
 
   const select = (day: Date) => {
     onSelect(day.getTime());
@@ -72,7 +74,7 @@ export function DayPicker({
       open={open}
       onOpenChange={(next) => {
         setOpen(next);
-        if (next) setViewMonth(startOfMonth(new Date(selectedMs)));
+        if (next) setViewMonth(startOfMonth(zoned(selectedMs, timeZone)));
       }}
     >
       <PopoverTrigger render={children} />

--- a/apps/web/src/components/calendar/event-card.tsx
+++ b/apps/web/src/components/calendar/event-card.tsx
@@ -13,6 +13,7 @@ import {
   type PositionedEvent,
   stackIndentPx,
   timePattern,
+  zoned,
 } from "./lib";
 import { pressTransition } from "./motion";
 import { useEventCapabilities } from "./permissions";
@@ -64,7 +65,7 @@ export function EventCard({
   } = positioned;
   const colorFor = useEventColor();
   const colorVar = colorFor(event);
-  const { use24h } = usePreferences();
+  const { use24h, timeZone } = usePreferences();
   // An event the user can't reschedule still opens on tap, but it shouldn't
   // offer a grab cursor or resize edges for a drag that will never happen.
   const { canEdit: draggable, canSeeGuests } = useEventCapabilities()(event);
@@ -143,7 +144,7 @@ export function EventCard({
           {event.summary ?? "(No title)"}
         </p>
         <p className="event-card-time truncate text-muted-foreground">
-          {`${format(event.startMs, timePattern(use24h, false))} – ${format(event.endMs, timePattern(use24h))}`}
+          {`${format(zoned(event.startMs, timeZone), timePattern(use24h, false))} – ${format(zoned(event.endMs, timeZone), timePattern(use24h))}`}
         </p>
         {(attendees.length > 0 || event.conferenceUrl) && (
           <div className="event-card-meta mt-auto min-w-0 items-center justify-between gap-1 pt-1">

--- a/apps/web/src/components/calendar/event-create.tsx
+++ b/apps/web/src/components/calendar/event-create.tsx
@@ -54,7 +54,7 @@ export function EventCreate({
 }) {
   const createEvent = useAction(api.domains.calendar.service.createEvent);
   const calendars = useQuery(api.domains.calendar.queries.listCalendars) ?? [];
-  const { defaultCalendarId } = usePreferences();
+  const { defaultCalendarId, timeZone } = usePreferences();
   const [submitting, setSubmitting] = useState(false);
   // Idempotency key for this create intent: minted once and reused across retries
   // (a lost response / re-submit) so the backend dedupes to one Google event
@@ -107,7 +107,7 @@ export function EventCreate({
     e.preventDefault();
     if (!valid || submitting) return;
     setSubmitting(true);
-    const times = toEventTimes(value);
+    const times = toEventTimes(value, timeZone);
     if (!operationIdRef.current) {
       operationIdRef.current = crypto.randomUUID();
     }
@@ -127,18 +127,18 @@ export function EventCreate({
       visibility: value.isPrivate ? "private" : undefined,
       // Busy is the provider default; only send the override when Free.
       busy: value.busy ? undefined : false,
-      recurrence: value.recurrence ? toRRule(value.recurrence) : undefined,
+      recurrence: value.recurrence
+        ? toRRule(value.recurrence, timeZone)
+        : undefined,
       attendees: value.guests.length
         ? value.guests.map((g) => ({
             email: g.email,
             displayName: g.displayName,
           }))
         : undefined,
-      // The browser zone, NOT the timezone preference: startMs/endMs are
-      // composed in browser-local wall clock (wheels, grid), and for a
-      // recurring event this zone becomes the series anchor — a different
-      // zone would drift instances across divergent DST transitions.
-      timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+      // The working zone: the grid renders in it and the wheels compose in
+      // it, so it is the honest recurrence anchor for this event's times.
+      timeZone,
     })
       .then(() => {
         operationIdRef.current = null;

--- a/apps/web/src/components/calendar/event-detail.tsx
+++ b/apps/web/src/components/calendar/event-detail.tsx
@@ -47,6 +47,7 @@ import {
   calendarDisplayName,
   editableEventId,
   timePattern,
+  zoned,
   type CalendarEvent,
 } from "./lib";
 import { dockVariants, dockVariantsReduced, press, SPRING_DOCK } from "./motion";
@@ -67,20 +68,26 @@ const RSVP_CHOICES = [
   { status: "declined", label: "No" },
 ] as const;
 
-function timeText(event: CalendarEvent, use24h: boolean): string {
+function timeText(
+  event: CalendarEvent,
+  use24h: boolean,
+  timeZone: string,
+): string {
+  const start = zoned(event.startMs, timeZone);
+  const end = zoned(event.endMs, timeZone);
   if (event.allDay) {
     // Google all-day endMs is exclusive midnight.
-    const lastDay = event.endMs - 1;
-    return isSameDay(event.startMs, lastDay)
-      ? format(event.startMs, "EEE d MMM")
-      : `${format(event.startMs, "EEE d MMM")} – ${format(lastDay, "EEE d MMM")}`;
+    const lastDay = zoned(event.endMs - 1, timeZone);
+    return isSameDay(start, lastDay)
+      ? format(start, "EEE d MMM")
+      : `${format(start, "EEE d MMM")} – ${format(lastDay, "EEE d MMM")}`;
   }
   const time = timePattern(use24h);
-  const end = format(
-    event.endMs,
-    isSameDay(event.startMs, event.endMs) ? time : `EEE d MMM, ${time}`,
+  const endText = format(
+    end,
+    isSameDay(start, end) ? time : `EEE d MMM, ${time}`,
   );
-  return `${format(event.startMs, `EEE d MMM, ${time}`)} – ${end}`;
+  return `${format(start, `EEE d MMM, ${time}`)} – ${endText}`;
 }
 
 function DetailRow({
@@ -480,7 +487,7 @@ export function EventDetail({
   onDuplicate: (prefill: EventPrefill, startMs: number, endMs: number) => void;
 }) {
   const reduce = useReducedMotion();
-  const { use24h } = usePreferences();
+  const { use24h, timeZone } = usePreferences();
   const deleteEvent = useAction(api.domains.calendar.service.deleteEvent);
   const refreshEventRecurrence = useAction(api.domains.calendar.service.refreshEventRecurrence);
   const calendars = useQuery(api.domains.calendar.queries.listCalendars) ?? [];
@@ -522,9 +529,11 @@ export function EventDetail({
     };
   }, [event._id, event.providerSeriesId, recurrenceLines, refreshEventRecurrence]);
 
-  const recurrence = recurrenceLines ? parseRRule(recurrenceLines) : null;
+  const recurrence = recurrenceLines
+    ? parseRRule(recurrenceLines, timeZone)
+    : null;
   const recurrenceSummary = recurrence
-    ? summarize(recurrence)
+    ? summarize(recurrence, timeZone)
     : recurrenceLines === undefined ||
         (recurrenceLines === null && recurrenceRefreshFailedFor !== event._id)
       ? undefined
@@ -698,7 +707,7 @@ export function EventDetail({
 
           <DetailRow icon={Clock01Icon}>
             <p className="text-sm font-medium text-foreground">
-              {timeText(event, use24h)}
+              {timeText(event, use24h, timeZone)}
             </p>
             <p className="text-xs text-muted-foreground">
               {formatDistanceToNowStrict(event.startMs, { addSuffix: true })}

--- a/apps/web/src/components/calendar/event-detail.tsx
+++ b/apps/web/src/components/calendar/event-detail.tsx
@@ -34,6 +34,7 @@ import { Avatar } from "./avatar";
 import { calendarColorVar, useEventColor } from "./colors";
 import { buttonClass } from "./event-controls";
 import type { EventPrefill } from "./event-create";
+import { fromUtcMidnight } from "./event-form";
 import { GoogleMeetIcon } from "./google-meet-icon";
 import {
   GuestRow,
@@ -46,6 +47,7 @@ import { usePreferences } from "@/components/workspace/preferences-context";
 import {
   calendarDisplayName,
   editableEventId,
+  MS_PER_DAY,
   timePattern,
   zoned,
   type CalendarEvent,
@@ -73,15 +75,20 @@ function timeText(
   use24h: boolean,
   timeZone: string,
 ): string {
-  const start = zoned(event.startMs, timeZone);
-  const end = zoned(event.endMs, timeZone);
   if (event.allDay) {
-    // Google all-day endMs is exclusive midnight.
-    const lastDay = zoned(event.endMs - 1, timeZone);
+    // All-day boundaries are UTC midnights (endMs exclusive); read them back
+    // through fromUtcMidnight so the working zone can't shift the day.
+    const start = zoned(fromUtcMidnight(event.startMs, timeZone), timeZone);
+    const lastDay = zoned(
+      fromUtcMidnight(event.endMs - MS_PER_DAY, timeZone),
+      timeZone,
+    );
     return isSameDay(start, lastDay)
       ? format(start, "EEE d MMM")
       : `${format(start, "EEE d MMM")} – ${format(lastDay, "EEE d MMM")}`;
   }
+  const start = zoned(event.startMs, timeZone);
+  const end = zoned(event.endMs, timeZone);
   const time = timePattern(use24h);
   const endText = format(
     end,
@@ -586,8 +593,13 @@ export function EventDetail({
           displayName: g.displayName,
         })),
       },
-      event.startMs,
-      event.endMs,
+      // The form works in working values; undo the all-day UTC-midnight
+      // conversion (as formValueFromEvent does) or submit re-applies it and
+      // the copy shifts or grows by a day.
+      event.allDay ? fromUtcMidnight(event.startMs, timeZone) : event.startMs,
+      event.allDay
+        ? fromUtcMidnight(event.endMs - MS_PER_DAY, timeZone)
+        : event.endMs,
     );
   };
 

--- a/apps/web/src/components/calendar/event-edit.test.ts
+++ b/apps/web/src/components/calendar/event-edit.test.ts
@@ -36,6 +36,7 @@ describe("event edit recurrence", () => {
       initial,
       next,
       { attendees: [] } as unknown as CalendarEvent,
+      "Asia/Shanghai",
     );
 
     expect(patch.recurrence).toEqual(["RRULE:FREQ=MONTHLY"]);

--- a/apps/web/src/components/calendar/event-edit.tsx
+++ b/apps/web/src/components/calendar/event-edit.tsx
@@ -15,6 +15,7 @@ import {
   toEventTimes,
   type EventFormValue,
 } from "./event-form";
+import { usePreferences } from "@/components/workspace/preferences-context";
 import { editableEventId, type CalendarEvent } from "./lib";
 import { useEventCapabilities } from "./permissions";
 import { toRRule } from "./rrule";
@@ -37,11 +38,14 @@ export type SaveScope = "thisEvent" | "thisAndFollowing" | "allEvents";
  * gives us both for free — untouched fields never appear, and a field the user
  * emptied appears as `null` rather than as `""`.
  */
+/** `timeZone` is the working zone the form's times were composed in — it
+ * shapes all-day boundaries, the recurrence UNTIL stamp, and the zone the
+ * patch is labeled with. */
 export function diffEvent(
   initial: EventFormValue,
   next: EventFormValue,
   event: CalendarEvent,
-  timeZone: string = Intl.DateTimeFormat().resolvedOptions().timeZone,
+  timeZone: string,
 ): EventPatch {
   const patch: EventPatch = {};
 
@@ -71,8 +75,8 @@ export function diffEvent(
 
   // Times travel together: the backend needs both ends to render either, and
   // all-day changes how both are written.
-  const times = toEventTimes(next);
-  const initialTimes = toEventTimes(initial);
+  const times = toEventTimes(next, timeZone);
+  const initialTimes = toEventTimes(initial, timeZone);
   if (
     times.startMs !== initialTimes.startMs ||
     times.endMs !== initialTimes.endMs ||
@@ -88,7 +92,7 @@ export function diffEvent(
     next.recurrence !== null &&
     JSON.stringify(next.recurrence) !== JSON.stringify(initial.recurrence)
   ) {
-    patch.recurrence = toRRule(next.recurrence);
+    patch.recurrence = toRRule(next.recurrence, timeZone);
   }
 
   const guestsChanged =
@@ -139,10 +143,11 @@ export function EventEdit({
 }) {
   const updateEvent = useAction(api.domains.calendar.service.updateEvent);
   const calendars = useQuery(api.domains.calendar.queries.listCalendars) ?? [];
+  const { timeZone } = usePreferences();
   const capabilities = useEventCapabilities()(event);
   // Captured once: the baseline every save diffs against. Re-seeding it from
   // `event` would erase edits in progress each time a sync lands.
-  const [initial] = useState(() => formValueFromEvent(event));
+  const [initial] = useState(() => formValueFromEvent(event, timeZone));
   const [value, setValue] = useState<EventFormValue>(initial);
   const [saving, setSaving] = useState(false);
   // Idempotency key for this save intent, reused across retries so a
@@ -157,9 +162,9 @@ export function EventEdit({
 
   const save = (scope: SaveScope) => {
     if (!valid || saving) return;
-    // Browser zone, not the timezone preference: the form's times are
-    // composed browser-locally, and this zone anchors recurring series.
-    const patch = diffEvent(initial, value, event);
+    // The working zone: the form composed its times in it, so it is the
+    // honest label and recurrence anchor.
+    const patch = diffEvent(initial, value, event, timeZone);
     if (Object.keys(patch).length === 0) {
       onSaved();
       return;
@@ -169,11 +174,7 @@ export function EventEdit({
     // requires a time zone on a recurring event. `diffEvent` only sets one when
     // the times change, so guarantee a zone here; an explicitly-diffed one still
     // wins since `patch` is spread last.
-    const finalPatch = finalizeEventPatch(
-      patch,
-      scope,
-      Intl.DateTimeFormat().resolvedOptions().timeZone,
-    );
+    const finalPatch = finalizeEventPatch(patch, scope, timeZone);
     if (!operationIdRef.current) {
       operationIdRef.current = crypto.randomUUID();
     }

--- a/apps/web/src/components/calendar/event-form.tsx
+++ b/apps/web/src/components/calendar/event-form.tsx
@@ -123,7 +123,7 @@ function toUtcMidnight(ms: number, timeZone: string): number {
 /** The inverse: a working-zone instant on the same calendar date, so the day
  * pickers show the day Google meant. Noon, so no DST shift can tip it into a
  * neighbouring day. */
-function fromUtcMidnight(ms: number, timeZone: string): number {
+export function fromUtcMidnight(ms: number, timeZone: string): number {
   const d = new Date(ms);
   return new TZDate(
     d.getUTCFullYear(),

--- a/apps/web/src/components/calendar/event-form.tsx
+++ b/apps/web/src/components/calendar/event-form.tsx
@@ -26,6 +26,8 @@ import { EventControls } from "./event-controls";
 import { FreeBusyToggle } from "./free-busy-toggle";
 import { GuestPicker, type Guest } from "./guest-picker";
 import { GoogleMeetIcon } from "./google-meet-icon";
+import { TZDate } from "@date-fns/tz";
+
 import { usePreferences } from "@/components/workspace/preferences-context";
 import {
   type CalendarEvent,
@@ -33,6 +35,7 @@ import {
   MS_PER_DAY,
   SNAP_MS,
   timePattern,
+  zoned,
 } from "./lib";
 import {
   dockVariants,
@@ -63,10 +66,11 @@ interface TimeParts {
   meridiem: string;
 }
 
-/** Split a timestamp into the wheel values. The minute is rounded onto the
- * wheel's step so an off-grid time can never fall through to row 0. */
-function partsOf(ms: number, use24h: boolean): TimeParts {
-  const d = new Date(ms);
+/** Split a timestamp into the wheel values, read in the working zone. The
+ * minute is rounded onto the wheel's step so an off-grid time can never fall
+ * through to row 0. */
+function partsOf(ms: number, use24h: boolean, timeZone: string): TimeParts {
+  const d = zoned(ms, timeZone);
   const minute = Math.min(
     Math.round(d.getMinutes() / MINUTE_STEP) * MINUTE_STEP,
     60 - MINUTE_STEP,
@@ -78,45 +82,55 @@ function partsOf(ms: number, use24h: boolean): TimeParts {
   };
 }
 
-/** Rebuild a timestamp from wheel values, keeping `baseMs`'s calendar day. */
-function withParts(baseMs: number, parts: TimeParts, use24h: boolean): number {
+/** Rebuild a timestamp from wheel values, keeping `baseMs`'s calendar day —
+ * both read and written in the working zone, so a wheel showing 9:00 always
+ * means 9:00 in the zone the grid displays. */
+function withParts(
+  baseMs: number,
+  parts: TimeParts,
+  use24h: boolean,
+  timeZone: string,
+): number {
   const h12 = Number(parts.hour) % 12;
   const hour = use24h
     ? Number(parts.hour)
     : parts.meridiem === "PM"
       ? h12 + 12
       : h12;
-  const d = new Date(baseMs);
+  const d = zoned(baseMs, timeZone);
   d.setHours(hour, Number(parts.minute), 0, 0);
   return d.getTime();
 }
 
-/** Move `baseMs` onto `dayMs`'s calendar day, keeping its time of day. */
-function withDay(baseMs: number, dayMs: number): number {
-  const day = new Date(dayMs);
-  const d = new Date(baseMs);
+/** Move `baseMs` onto `dayMs`'s calendar day (working zone), keeping its
+ * time of day. */
+function withDay(baseMs: number, dayMs: number, timeZone: string): number {
+  const day = zoned(dayMs, timeZone);
+  const d = zoned(baseMs, timeZone);
   d.setFullYear(day.getFullYear(), day.getMonth(), day.getDate());
   return d.getTime();
 }
 
-/** UTC midnight of a timestamp's local calendar day — the instant Google's
- * all-day date strings map to (see mapGoogleEvent / toGoogleTime on the
- * backend). All-day events are stored and sent as these UTC-midnight instants. */
-function toUtcMidnight(ms: number): number {
-  const d = new Date(ms);
+/** UTC midnight of a timestamp's working-zone calendar day — the instant
+ * Google's all-day date strings map to (see mapGoogleEvent / toGoogleTime on
+ * the backend). All-day events are stored and sent as these UTC-midnight
+ * instants. */
+function toUtcMidnight(ms: number, timeZone: string): number {
+  const d = zoned(ms, timeZone);
   return Date.UTC(d.getFullYear(), d.getMonth(), d.getDate());
 }
 
-/** The inverse: a local-time instant on the same calendar date, so the day
+/** The inverse: a working-zone instant on the same calendar date, so the day
  * pickers show the day Google meant. Noon, so no DST shift can tip it into a
  * neighbouring day. */
-function fromUtcMidnight(ms: number): number {
+function fromUtcMidnight(ms: number, timeZone: string): number {
   const d = new Date(ms);
-  return new Date(
+  return new TZDate(
     d.getUTCFullYear(),
     d.getUTCMonth(),
     d.getUTCDate(),
     12,
+    timeZone,
   ).getTime();
 }
 
@@ -154,8 +168,12 @@ export function isEventFormValid(value: EventFormValue): boolean {
 }
 
 /** The instants to send to Google. All-day events are date-only: UTC midnight
- * of the first day, and the exclusive UTC midnight *after* the last one. */
-export function toEventTimes(value: EventFormValue): {
+ * of the first day (as read in the working zone), and the exclusive UTC
+ * midnight *after* the last one. */
+export function toEventTimes(
+  value: EventFormValue,
+  timeZone: string,
+): {
   startMs: number;
   endMs: number;
 } {
@@ -163,24 +181,29 @@ export function toEventTimes(value: EventFormValue): {
     return { startMs: value.startMs, endMs: value.endMs };
   }
   return {
-    startMs: toUtcMidnight(value.startMs),
-    endMs: toUtcMidnight(value.endMs) + MS_PER_DAY,
+    startMs: toUtcMidnight(value.startMs, timeZone),
+    endMs: toUtcMidnight(value.endMs, timeZone) + MS_PER_DAY,
   };
 }
 
 /** Seed the form from a synced event. Undoes the all-day conversion above, so
  * the end tab shows the last day of the event rather than the exclusive one
  * after it. */
-export function formValueFromEvent(event: CalendarEvent): EventFormValue {
+export function formValueFromEvent(
+  event: CalendarEvent,
+  timeZone: string,
+): EventFormValue {
   return {
     summary: event.summary ?? "",
     description: event.description ?? "",
     location: event.location ?? "",
     meet: event.conferenceType === "hangoutsMeet",
     conferenceUrl: event.conferenceUrl,
-    startMs: event.allDay ? fromUtcMidnight(event.startMs) : event.startMs,
+    startMs: event.allDay
+      ? fromUtcMidnight(event.startMs, timeZone)
+      : event.startMs,
     endMs: event.allDay
-      ? fromUtcMidnight(event.endMs - MS_PER_DAY)
+      ? fromUtcMidnight(event.endMs - MS_PER_DAY, timeZone)
       : event.endMs,
     allDay: event.allDay,
     isPrivate: event.visibility === "private",
@@ -265,13 +288,13 @@ export function EventForm({
   const [mainHeight, setMainHeight] = useState<number>();
 
   const { canEdit } = capabilities;
-  const { use24h } = usePreferences();
+  const { use24h, timeZone } = usePreferences();
   const valid = isEventFormValid(value);
   const activeMs = editing === "start" ? value.startMs : value.endMs;
-  const parts = partsOf(activeMs, use24h);
+  const parts = partsOf(activeMs, use24h, timeZone);
 
   const setPart = (key: keyof TimeParts, part: string) => {
-    const next = withParts(activeMs, { ...parts, [key]: part }, use24h);
+    const next = withParts(activeMs, { ...parts, [key]: part }, use24h, timeZone);
     if (editing === "start") {
       // Drag the end along so the duration survives a later start.
       onChangeRange(next, Math.max(value.endMs, next + SNAP_MS));
@@ -283,7 +306,7 @@ export function EventForm({
   // Move the active side onto a chosen day, keeping its time of day. The end can
   // never land before the start; the start drags the end along to hold duration.
   const setDay = (dayMs: number) => {
-    const next = withDay(activeMs, dayMs);
+    const next = withDay(activeMs, dayMs, timeZone);
     if (editing === "start") {
       onChangeRange(next, Math.max(value.endMs, next + SNAP_MS));
     } else {
@@ -294,7 +317,7 @@ export function EventForm({
   // `custom` is the travel direction of the drill-down: the entering screen
   // declares its own, the exiting one reads it off the AnimatePresence.
   const variants = reduce ? dockVariantsReduced : dockVariants;
-  const dayLabel = format(activeMs, "EEE, MMM d, yyyy");
+  const dayLabel = format(zoned(activeMs, timeZone), "EEE, MMM d, yyyy");
 
   return (
     <AnimatePresence
@@ -446,7 +469,7 @@ export function EventForm({
                     side="top"
                     minMs={
                       editing === "end"
-                        ? startOfDay(value.startMs).getTime()
+                        ? startOfDay(zoned(value.startMs, timeZone)).getTime()
                         : undefined
                     }
                   >
@@ -614,7 +637,7 @@ function TimeTab({
   active: boolean;
   onSelect: () => void;
 }) {
-  const { use24h } = usePreferences();
+  const { use24h, timeZone } = usePreferences();
   return (
     <motion.button
       type="button"
@@ -629,10 +652,10 @@ function TimeTab({
       )}
     >
       <span className="truncate text-xs font-medium text-muted-foreground">
-        {label} · {format(ms, "EEE d")}
+        {label} · {format(zoned(ms, timeZone), "EEE d")}
       </span>
       <span className={cn("text-sm font-semibold", active && "text-foreground")}>
-        {allDay ? "All day" : format(ms, timePattern(use24h))}
+        {allDay ? "All day" : format(zoned(ms, timeZone), timePattern(use24h))}
       </span>
     </motion.button>
   );

--- a/apps/web/src/components/calendar/ghost-event.tsx
+++ b/apps/web/src/components/calendar/ghost-event.tsx
@@ -7,6 +7,7 @@ import {
   msToPct,
   MS_PER_MINUTE,
   timePattern,
+  zoned,
 } from "./lib";
 
 interface GhostEventProps {
@@ -28,7 +29,7 @@ export function GhostEvent({
   wallClock = false,
   variant = "create",
 }: GhostEventProps) {
-  const { use24h } = usePreferences();
+  const { use24h, timeZone } = usePreferences();
   const topPct = msToPct(startMs, dayStartMs);
   const heightPct = msToPct(endMs, dayStartMs) - topPct;
   const rangeLabel = wallClock
@@ -37,7 +38,7 @@ export function GhostEvent({
         false,
         use24h,
       )} – ${formatWallClockMinutes((endMs - dayStartMs) / MS_PER_MINUTE, true, use24h)}`
-    : `${format(startMs, timePattern(use24h, false))} – ${format(endMs, timePattern(use24h))}`;
+    : `${format(zoned(startMs, timeZone), timePattern(use24h, false))} – ${format(zoned(endMs, timeZone), timePattern(use24h))}`;
   return (
     <div
       className={cn(

--- a/apps/web/src/components/calendar/gutter-column.tsx
+++ b/apps/web/src/components/calendar/gutter-column.tsx
@@ -12,17 +12,29 @@ import {
   MIN_DAY_HEIGHT,
   msToPct,
   TIME_GRID_BOTTOM_SPACER_HEIGHT,
-  TIMEZONES,
+  timezoneGutters,
+  zoned,
+  zonedNow,
 } from "./lib";
 import { TimeGutter } from "./time-gutter";
 
-function formatNow(now: number, use24h: boolean): string {
-  return new Intl.DateTimeFormat("en-US", {
-    hour: "numeric",
-    minute: "2-digit",
-    timeZone: TIMEZONES[0].id,
-    hour12: !use24h,
-  })
+/** Formatters are the costliest Intl construction; cache per zone/clock so
+ * the drag/scroll-driven re-renders of this column reuse them. */
+const nowFormatters = new Map<string, Intl.DateTimeFormat>();
+
+function formatNow(now: number, use24h: boolean, timeZone: string): string {
+  const key = `${timeZone}:${use24h}`;
+  let fmt = nowFormatters.get(key);
+  if (!fmt) {
+    fmt = new Intl.DateTimeFormat("en-US", {
+      hour: "numeric",
+      minute: "2-digit",
+      timeZone,
+      hour12: !use24h,
+    });
+    nowFormatters.set(key, fmt);
+  }
+  return fmt
     .formatToParts(now)
     .filter(({ type }) => type !== "dayPeriod")
     .map(({ value }) => value)
@@ -45,16 +57,17 @@ export function GutterColumn({
   onToggleAllDay: () => void;
   now: number;
 }) {
-  const { use24h } = usePreferences();
-  const dayStartMs = startOfDay(new Date()).getTime();
-  const nowTopPct = msToPct(now, startOfDay(now).getTime());
+  const { use24h, timeZone } = usePreferences();
+  const gutters = timezoneGutters(timeZone);
+  const dayStartMs = startOfDay(zonedNow(timeZone)).getTime();
+  const nowTopPct = msToPct(now, startOfDay(zoned(now, timeZone)).getTime());
   return (
     <div className="flex h-full flex-col bg-background">
       <div
         className="sticky top-0 z-10 flex shrink-0 items-start gap-1 border-b border-border bg-calendar-header px-1.5 py-2 backdrop-blur-xs transition-[height] duration-200 motion-reduce:transition-none"
         style={{ height: HEADER_DATE_HEIGHT + allDayHeight }}
       >
-        {TIMEZONES.map((tz) => (
+        {gutters.map((tz) => (
           <span
             key={tz.id}
             className="min-w-0 flex-1 truncate text-[10px] text-muted-foreground"
@@ -93,7 +106,7 @@ export function GutterColumn({
         className="relative flex flex-1 bg-background"
         style={{ minHeight: MIN_DAY_HEIGHT }}
       >
-        {TIMEZONES.map((tz) => (
+        {gutters.map((tz) => (
           <div key={tz.id} className="h-full" style={{ width: GUTTER_WIDTH }}>
             <TimeGutter timeZone={tz.id} dayStartMs={dayStartMs} />
           </div>
@@ -102,7 +115,7 @@ export function GutterColumn({
           className="pointer-events-none absolute right-1.5 z-0 -translate-y-1/2 rounded-full bg-red-500 px-1.5 py-0.5 text-xs font-semibold leading-none tabular-nums text-white shadow-sm"
           style={{ top: `${nowTopPct}%` }}
         >
-          {formatNow(now, use24h)}
+          {formatNow(now, use24h, timeZone)}
           <span
             aria-hidden
             className="absolute top-1/2 left-full h-0.5 w-1.5 -translate-y-1/2 bg-red-500"

--- a/apps/web/src/components/calendar/gutter-column.tsx
+++ b/apps/web/src/components/calendar/gutter-column.tsx
@@ -3,7 +3,7 @@ import {
   ArrowUp01Icon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
-import { startOfDay } from "date-fns";
+import { format, startOfDay } from "date-fns";
 
 import { usePreferences } from "@/components/workspace/preferences-context";
 import {
@@ -12,35 +12,11 @@ import {
   MIN_DAY_HEIGHT,
   msToPct,
   TIME_GRID_BOTTOM_SPACER_HEIGHT,
+  timePattern,
   timezoneGutters,
   zoned,
-  zonedNow,
 } from "./lib";
 import { TimeGutter } from "./time-gutter";
-
-/** Formatters are the costliest Intl construction; cache per zone/clock so
- * the drag/scroll-driven re-renders of this column reuse them. */
-const nowFormatters = new Map<string, Intl.DateTimeFormat>();
-
-function formatNow(now: number, use24h: boolean, timeZone: string): string {
-  const key = `${timeZone}:${use24h}`;
-  let fmt = nowFormatters.get(key);
-  if (!fmt) {
-    fmt = new Intl.DateTimeFormat("en-US", {
-      hour: "numeric",
-      minute: "2-digit",
-      timeZone,
-      hour12: !use24h,
-    });
-    nowFormatters.set(key, fmt);
-  }
-  return fmt
-    .formatToParts(now)
-    .filter(({ type }) => type !== "dayPeriod")
-    .map(({ value }) => value)
-    .join("")
-    .trim();
-}
 
 /** The hour-labels column, pinned to the left of the paging day/week panels.
  * Its header block matches the panel header height so the hour rows align. */
@@ -59,8 +35,9 @@ export function GutterColumn({
 }) {
   const { use24h, timeZone } = usePreferences();
   const gutters = timezoneGutters(timeZone);
-  const dayStartMs = startOfDay(zonedNow(timeZone)).getTime();
-  const nowTopPct = msToPct(now, startOfDay(zoned(now, timeZone)).getTime());
+  const nowDate = zoned(now, timeZone);
+  const dayStartMs = startOfDay(nowDate).getTime();
+  const nowTopPct = msToPct(now, dayStartMs);
   return (
     <div className="flex h-full flex-col bg-background">
       <div
@@ -107,7 +84,9 @@ export function GutterColumn({
         style={{ minHeight: MIN_DAY_HEIGHT }}
       >
         {gutters.map((tz) => (
-          <div key={tz.id} className="h-full" style={{ width: GUTTER_WIDTH }}>
+          // Flex stretch (not h-full): the gutter wrapper is content-height
+          // now, so a percentage chain has nothing definite to resolve against.
+          <div key={tz.id} style={{ width: GUTTER_WIDTH }}>
             <TimeGutter timeZone={tz.id} dayStartMs={dayStartMs} />
           </div>
         ))}
@@ -115,7 +94,7 @@ export function GutterColumn({
           className="pointer-events-none absolute right-1.5 z-0 -translate-y-1/2 rounded-full bg-red-500 px-1.5 py-0.5 text-xs font-semibold leading-none tabular-nums text-white shadow-sm"
           style={{ top: `${nowTopPct}%` }}
         >
-          {formatNow(now, use24h, timeZone)}
+          {format(nowDate, timePattern(use24h, false))}
           <span
             aria-hidden
             className="absolute top-1/2 left-full h-0.5 w-1.5 -translate-y-1/2 bg-red-500"

--- a/apps/web/src/components/calendar/lib.ts
+++ b/apps/web/src/components/calendar/lib.ts
@@ -1,3 +1,4 @@
+import { TZDate } from "@date-fns/tz";
 import type { api } from "@qali/backend/convex/_generated/api";
 import type { Id } from "@qali/backend/convex/_generated/dataModel";
 import type { EventView } from "@qali/backend/convex/domains/calendar/model";
@@ -13,6 +14,25 @@ import {
   startOfMonth,
   startOfWeek,
 } from "date-fns";
+
+// The working time zone
+//
+// The calendar operates in ONE zone — the user's timezone preference, falling
+// back to the browser's (see usePreferences) — for everything: day cuts,
+// labels, wheel composition, and the zone stamped on writes. date-fns v4
+// propagates a TZDate's zone through its functions, so the discipline is
+// simple: every Date that enters calendar math is created by `zoned`/
+// `zonedNow` below, and everything derived from it stays in the working zone.
+
+/** An instant viewed in the working zone. */
+export function zoned(ms: number, timeZone: string): TZDate {
+  return new TZDate(ms, timeZone);
+}
+
+/** The current instant viewed in the working zone. */
+export function zonedNow(timeZone: string): TZDate {
+  return new TZDate(Date.now(), timeZone);
+}
 
 /** An event as the grid renders it: a synced `events` row, or a public
  * `sharedEvents` row (holiday/birthday) in the same shape. Its `_id` is the
@@ -110,13 +130,16 @@ export const STRIP_SIDE_DAYS: Record<StripView, number> = {
  * object. Stepping the anchor rebuilds the strip but keeps all but one column's
  * `day` prop referentially equal, which is what lets the memoized day columns
  * skip re-rendering on the settle frame. */
-const dayCache = new Map<number, Date>();
+const dayCache = new Map<string, Date>();
 /** Comfortably more than the widest strip plus a few anchor steps; trimmed
  * wholesale rather than by LRU since a stale entry costs only a re-render. */
 const DAY_CACHE_LIMIT = 512;
 
 function internDay(date: Date): Date {
-  const key = date.getTime();
+  // The zone is part of the key: the same instant carries different calendar
+  // components per zone, and handing back a cached day from a previous
+  // working zone would resurrect the old zone's labels.
+  const key = `${date instanceof TZDate ? date.timeZone : "local"}:${date.getTime()}`;
   const cached = dayCache.get(key);
   if (cached) return cached;
   if (dayCache.size >= DAY_CACHE_LIMIT) dayCache.clear();
@@ -352,19 +375,26 @@ export function visibleMonthEventMetrics(
   return { visibleCount, hiddenCount: eventCount - visibleCount };
 }
 
-const LOCAL_TZ = Intl.DateTimeFormat().resolvedOptions().timeZone;
+/** A zone's short human label, e.g. "New York" from "America/New_York". */
+export function zoneShortLabel(zone: string): string {
+  return zone.split("/").pop()?.replace(/_/g, " ") ?? zone;
+}
 
 /** Timezones shown as time gutters, left to right. First is the primary day
- * scale. For now only the user's current timezone is shown; additional zones
- * will be appended here when multi-timezone support lands. */
-export const TIMEZONES: { id: string; label: string }[] = [
-  { id: LOCAL_TZ, label: LOCAL_TZ.split("/").pop()?.replace(/_/g, " ") ?? "Local" },
-];
+ * scale — the working zone. Additional zones will be appended here when
+ * multi-timezone support lands. */
+export function timezoneGutters(
+  workingZone: string,
+): { id: string; label: string }[] {
+  return [{ id: workingZone, label: zoneShortLabel(workingZone) }];
+}
 
+/** How many gutters render — a layout constant so widths can't drift. */
+export const GUTTER_COUNT = 1;
 /** Width of each timezone gutter column, in pixels. */
 export const GUTTER_WIDTH = 64;
 /** Total width of all gutter columns — where the day columns begin. */
-export const GUTTER_TOTAL = GUTTER_WIDTH * TIMEZONES.length;
+export const GUTTER_TOTAL = GUTTER_WIDTH * GUTTER_COUNT;
 
 /** Grid template for `n` equal day columns (the gutter is a pinned sibling). */
 export function dayColsTemplate(n: number): string {
@@ -525,8 +555,9 @@ export function msToPct(ms: number, dayStartMs: number): number {
 }
 
 /** Stable reveal key for a whole day (today's pill, a month cell). Events and
- * requests reveal by their own id instead; a day is keyed by its local midnight
- * so the same string is produced from a `Date` or an instant within the day. */
+ * requests reveal by their own id instead; a day is keyed by its midnight —
+ * in the working zone when handed a `zoned` date (which every caller should),
+ * browser-local for a bare `Date`/instant. */
 export function dayKey(date: Date | number): string {
   return `day:${startOfDay(date).getTime()}`;
 }

--- a/apps/web/src/components/calendar/lib.ts
+++ b/apps/web/src/components/calendar/lib.ts
@@ -389,12 +389,12 @@ export function timezoneGutters(
   return [{ id: workingZone, label: zoneShortLabel(workingZone) }];
 }
 
-/** How many gutters render — a layout constant so widths can't drift. */
-export const GUTTER_COUNT = 1;
 /** Width of each timezone gutter column, in pixels. */
 export const GUTTER_WIDTH = 64;
-/** Total width of all gutter columns — where the day columns begin. */
-export const GUTTER_TOTAL = GUTTER_WIDTH * GUTTER_COUNT;
+/** Total width of all gutter columns — where the day columns begin. Derived
+ * from the gutter list itself (its length doesn't depend on the zone) so the
+ * two can't drift when more zones land. */
+export const GUTTER_TOTAL = GUTTER_WIDTH * timezoneGutters("UTC").length;
 
 /** Grid template for `n` equal day columns (the gutter is a pinned sibling). */
 export function dayColsTemplate(n: number): string {

--- a/apps/web/src/components/calendar/month-panel.tsx
+++ b/apps/web/src/components/calendar/month-panel.tsx
@@ -44,8 +44,18 @@ export function MonthPanel({ monthStart, days, events, onSelectDay, reveal }: Mo
     return days.map((day) => {
       const dayStartMs = day.getTime();
       const dayEndMs = dayStartMs + MS_PER_DAY;
+      // All-day boundaries are UTC-midnight instants (see allDayColumnSpan);
+      // compare them against the cell's calendar date in UTC, or a working-zone
+      // offset spills a single-day chip into the neighbouring cell.
+      const dayUtcMs = Date.UTC(day.getFullYear(), day.getMonth(), day.getDate());
       return events
-        .filter((e) => e.startMs < dayEndMs && e.endMs > dayStartMs && e.status !== "cancelled")
+        .filter(
+          (e) =>
+            e.status !== "cancelled" &&
+            (e.allDay
+              ? e.startMs <= dayUtcMs && dayUtcMs < e.endMs
+              : e.startMs < dayEndMs && e.endMs > dayStartMs),
+        )
         .sort((a, b) => Number(b.allDay) - Number(a.allDay) || a.startMs - b.startMs);
     });
   }, [days, events]);

--- a/apps/web/src/components/calendar/now-indicator.test.ts
+++ b/apps/web/src/components/calendar/now-indicator.test.ts
@@ -10,13 +10,17 @@ import { getNowIndicatorLayout } from "./now-indicator";
 const WEEK_SIDE = STRIP_SIDE_DAYS.week;
 const DAY_SIDE = STRIP_SIDE_DAYS.day;
 
+// These cases build their strips from runner-local Dates, so the runner's own
+// zone is the working zone; working-zone.test.ts covers explicit zones.
+const TZ = Intl.DateTimeFormat().resolvedOptions().timeZone;
+
 describe("getNowIndicatorLayout", () => {
   test("positions today's column within the full buffered strip", () => {
     const weekStart = new Date(2026, 6, 13);
     const days = stripDays(weekStart, VIEW_COLUMNS.week, WEEK_SIDE);
     const now = new Date(2026, 6, 19, 9, 30).getTime();
 
-    const layout = getNowIndicatorLayout(days, now);
+    const layout = getNowIndicatorLayout(days, now, TZ);
 
     expect(layout).not.toBeNull();
     // July 19 is 6 days after the anchor, which itself sits at WEEK_SIDE.
@@ -31,7 +35,7 @@ describe("getNowIndicatorLayout", () => {
     const days = stripDays(today, VIEW_COLUMNS.day, DAY_SIDE);
     const now = new Date(2026, 6, 19, 15).getTime();
 
-    const layout = getNowIndicatorLayout(days, now);
+    const layout = getNowIndicatorLayout(days, now, TZ);
 
     expect(layout).not.toBeNull();
     expect(layout?.today?.leftPct).toBeCloseTo((DAY_SIDE / days.length) * 100);
@@ -44,7 +48,7 @@ describe("getNowIndicatorLayout", () => {
     const days = stripDays(visibleStart, VIEW_COLUMNS.week, WEEK_SIDE);
     const now = new Date(2026, 6, 19, 12).getTime();
 
-    const layout = getNowIndicatorLayout(days, now);
+    const layout = getNowIndicatorLayout(days, now, TZ);
 
     // The current-time line always renders; today's column is still marked so
     // long as the day sits somewhere in the buffered strip.
@@ -59,8 +63,8 @@ describe("getNowIndicatorLayout", () => {
     const beforeMidnight = new Date(2026, 6, 19, 23, 59).getTime();
     const afterMidnight = new Date(2026, 6, 20, 0, 0).getTime();
 
-    const before = getNowIndicatorLayout(days, beforeMidnight);
-    const after = getNowIndicatorLayout(days, afterMidnight);
+    const before = getNowIndicatorLayout(days, beforeMidnight, TZ);
+    const after = getNowIndicatorLayout(days, afterMidnight, TZ);
 
     // The marked column advances one day across midnight.
     const julyNineteenth = WEEK_SIDE + 6;

--- a/apps/web/src/components/calendar/now-indicator.tsx
+++ b/apps/web/src/components/calendar/now-indicator.tsx
@@ -16,15 +16,15 @@ export interface NowIndicatorLayout {
 
 /** Indicator geometry: a full-width line at the current time, plus today's
  * column when it falls inside the buffered strip. `timeZone` is the working
- * zone the `days` were cut in; without it, "now" reads browser-local. */
+ * zone the `days` were cut in, so "now" is read on the same clock. */
 export function getNowIndicatorLayout(
   days: Date[],
   now: number,
-  timeZone?: string,
+  timeZone: string,
 ): NowIndicatorLayout | null {
   if (days.length === 0) return null;
 
-  const zonedNowDate = timeZone ? zoned(now, timeZone) : now;
+  const zonedNowDate = zoned(now, timeZone);
   const todayIndex = days.findIndex((day) => isSameDay(day, zonedNowDate));
 
   return {

--- a/apps/web/src/components/calendar/now-indicator.tsx
+++ b/apps/web/src/components/calendar/now-indicator.tsx
@@ -1,6 +1,6 @@
 import { isSameDay, startOfDay } from "date-fns";
 
-import { msToPct } from "./lib";
+import { msToPct, zoned } from "./lib";
 
 export interface NowIndicatorLayout {
   /** Vertical position within the 24-hour body. */
@@ -15,17 +15,20 @@ export interface NowIndicatorLayout {
 }
 
 /** Indicator geometry: a full-width line at the current time, plus today's
- * column when it falls inside the buffered strip. */
+ * column when it falls inside the buffered strip. `timeZone` is the working
+ * zone the `days` were cut in; without it, "now" reads browser-local. */
 export function getNowIndicatorLayout(
   days: Date[],
   now: number,
+  timeZone?: string,
 ): NowIndicatorLayout | null {
   if (days.length === 0) return null;
 
-  const todayIndex = days.findIndex((day) => isSameDay(day, now));
+  const zonedNowDate = timeZone ? zoned(now, timeZone) : now;
+  const todayIndex = days.findIndex((day) => isSameDay(day, zonedNowDate));
 
   return {
-    topPct: msToPct(now, startOfDay(now).getTime()),
+    topPct: msToPct(now, startOfDay(zonedNowDate).getTime()),
     today:
       todayIndex === -1
         ? null

--- a/apps/web/src/components/calendar/repeat-control.tsx
+++ b/apps/web/src/components/calendar/repeat-control.tsx
@@ -4,10 +4,12 @@ import {
   PopoverTrigger,
 } from "@qali/ui/components/popover";
 import { cn } from "@qali/ui/lib/utils";
-import { addMonths } from "date-fns";
+import { addMonths, format } from "date-fns";
 import { useState } from "react";
 
+import { usePreferences } from "@/components/workspace/preferences-context";
 import { DayPicker } from "./day-picker";
+import { zoned } from "./lib";
 import {
   defaultRecurrence,
   type Freq,
@@ -35,7 +37,10 @@ const FREQ_TABS: { freq: Freq; label: string; noun: string }[] = [
   { freq: "YEARLY", label: "Year", noun: "year" },
 ];
 
-const PRESETS = (startMs: number): { label: string; value: Recurrence | null }[] => [
+const PRESETS = (
+  startMs: number,
+  timeZone: string,
+): { label: string; value: Recurrence | null }[] => [
   { label: "Does not repeat", value: null },
   { label: "Daily", value: { freq: "DAILY", interval: 1, end: { kind: "never" } } },
   {
@@ -43,7 +48,7 @@ const PRESETS = (startMs: number): { label: string; value: Recurrence | null }[]
     value: {
       freq: "WEEKLY",
       interval: 1,
-      byWeekday: [weekdayOf(startMs)],
+      byWeekday: [weekdayOf(startMs, timeZone)],
       end: { kind: "never" },
     },
   },
@@ -71,10 +76,11 @@ export function RepeatControl({
   value: Recurrence | null;
   onChange: (r: Recurrence | null) => void;
 }) {
+  const { timeZone } = usePreferences();
   const [open, setOpen] = useState(false);
   // The custom editor always works against a concrete rule; when nothing is set
   // yet it seeds from a sensible default so any edit turns repetition on.
-  const draft = value ?? defaultRecurrence(startMs);
+  const draft = value ?? defaultRecurrence(startMs, timeZone);
   const patch = (next: Partial<Recurrence>) => onChange({ ...draft, ...next });
 
   const endKind = value?.end.kind ?? "never";
@@ -82,11 +88,11 @@ export function RepeatControl({
   return (
     <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger className="flex-1 truncate rounded-lg px-2 py-1 text-right text-sm font-medium outline-none hover:bg-accent focus-visible:ring-2 focus-visible:ring-ring">
-        {value ? summarize(value) : "Does not repeat"}
+        {value ? summarize(value, timeZone) : "Does not repeat"}
       </PopoverTrigger>
       <PopoverContent side="top" align="end" className="w-[22rem] p-2">
         <div className="flex flex-col gap-1">
-          {PRESETS(startMs).map((preset) => {
+          {PRESETS(startMs, timeZone).map((preset) => {
             const active = presetMatches(preset.value, value);
             return (
               <button
@@ -132,7 +138,7 @@ export function RepeatControl({
                       freq: tab.freq,
                       byWeekday:
                         tab.freq === "WEEKLY"
-                          ? (draft.byWeekday ?? [weekdayOf(startMs)])
+                          ? (draft.byWeekday ?? [weekdayOf(startMs, timeZone)])
                           : undefined,
                     })
                   }
@@ -181,7 +187,7 @@ export function RepeatControl({
                   patch({
                     end: {
                       kind: "onDate",
-                      dateMs: addMonths(new Date(startMs), 1).getTime(),
+                      dateMs: addMonths(zoned(startMs, timeZone), 1).getTime(),
                     },
                   })
                 }
@@ -209,11 +215,7 @@ export function RepeatControl({
                     type="button"
                     className="rounded-lg px-2 py-1 text-sm font-medium outline-none hover:bg-accent focus-visible:ring-2 focus-visible:ring-ring"
                   >
-                    {new Date(value.end.dateMs).toLocaleDateString(undefined, {
-                      month: "short",
-                      day: "numeric",
-                      year: "numeric",
-                    })}
+                    {format(zoned(value.end.dateMs, timeZone), "MMM d, yyyy")}
                   </button>
                 </DayPicker>
               </div>

--- a/apps/web/src/components/calendar/rrule.test.ts
+++ b/apps/web/src/components/calendar/rrule.test.ts
@@ -4,9 +4,12 @@ import { describe, expect, test } from "bun:test";
 
 import { parseRRule, summarize } from "./rrule";
 
+/** A fixed working zone so the assertions don't depend on the machine's. */
+const TZ = "America/New_York";
+
 function summary(rule: string): string | null {
-  const recurrence = parseRRule([rule]);
-  return recurrence ? summarize(recurrence) : null;
+  const recurrence = parseRRule([rule], TZ);
+  return recurrence ? summarize(recurrence, TZ) : null;
 }
 
 describe("parseRRule", () => {
@@ -29,17 +32,17 @@ describe("parseRRule", () => {
   });
 
   test("ignores non-rule recurrence lines", () => {
-    const recurrence = parseRRule([
-      "EXDATE:20260812T090000Z",
-      "RRULE:FREQ=MONTHLY",
-    ]);
-    expect(recurrence && summarize(recurrence)).toBe("Monthly");
+    const recurrence = parseRRule(
+      ["EXDATE:20260812T090000Z", "RRULE:FREQ=MONTHLY"],
+      TZ,
+    );
+    expect(recurrence && summarize(recurrence, TZ)).toBe("Monthly");
   });
 
   test("rejects malformed or unsupported rules", () => {
-    expect(parseRRule(["RRULE:FREQ=DAILY;INTERVAL=0"])).toBeNull();
-    expect(parseRRule(["RRULE:FREQ=MONTHLY;BYDAY=1MO"])).toBeNull();
-    expect(parseRRule(["RRULE:FREQ=DAILY;UNTIL=20260230"])).toBeNull();
-    expect(parseRRule(["RDATE:20260826T090000Z"])).toBeNull();
+    expect(parseRRule(["RRULE:FREQ=DAILY;INTERVAL=0"], TZ)).toBeNull();
+    expect(parseRRule(["RRULE:FREQ=MONTHLY;BYDAY=1MO"], TZ)).toBeNull();
+    expect(parseRRule(["RRULE:FREQ=DAILY;UNTIL=20260230"], TZ)).toBeNull();
+    expect(parseRRule(["RDATE:20260826T090000Z"], TZ)).toBeNull();
   });
 });

--- a/apps/web/src/components/calendar/rrule.test.ts
+++ b/apps/web/src/components/calendar/rrule.test.ts
@@ -19,6 +19,14 @@ describe("parseRRule", () => {
     );
   });
 
+  test("reads a Google-normalized UTC UNTIL back as the authored day", () => {
+    // Google emits end-of-day in the rule's own zone as a UTC instant; a
+    // New-York "ends Aug 26" arrives as 03:59:59Z the next day.
+    expect(summary("RRULE:FREQ=DAILY;UNTIL=20260827T035959Z")).toBe(
+      "Daily · until Aug 26, 2026",
+    );
+  });
+
   test("describes weekly days in display order", () => {
     expect(summary("RRULE:FREQ=WEEKLY;BYDAY=WE,MO")).toBe(
       "Weekly on Mon, Wed",

--- a/apps/web/src/components/calendar/rrule.ts
+++ b/apps/web/src/components/calendar/rrule.ts
@@ -140,11 +140,17 @@ export function toRRule(r: Recurrence, timeZone: string): string[] {
   if (r.end.kind === "count") {
     parts.push(`COUNT=${Math.max(1, r.end.count)}`);
   } else if (r.end.kind === "onDate") {
-    // UNTIL is inclusive; pin it to end-of-day UTC so the chosen day counts.
+    // UNTIL is inclusive; stamp the working zone's end of the chosen day as a
+    // real UTC instant (Google's own convention), so every occurrence on that
+    // day counts and parseUntilDate reads the same day back.
     const d = zoned(r.end.dateMs, timeZone);
-    const stamp = `${d.getFullYear()}${pad(d.getMonth() + 1)}${pad(
-      d.getDate(),
-    )}T235959Z`;
+    d.setHours(23, 59, 59, 0);
+    const u = new Date(d.getTime());
+    const stamp = `${u.getUTCFullYear()}${pad(u.getUTCMonth() + 1)}${pad(
+      u.getUTCDate(),
+    )}T${pad(u.getUTCHours())}${pad(u.getUTCMinutes())}${pad(
+      u.getUTCSeconds(),
+    )}Z`;
     parts.push(`UNTIL=${stamp}`);
   }
   return [`RRULE:${parts.join(";")}`];
@@ -200,22 +206,42 @@ function positiveInteger(value: string): number | null {
   return Number.isSafeInteger(parsed) ? parsed : null;
 }
 
-/** UNTIL may be a date or UTC date-time. The control selects a calendar date,
- * so preserve its YYYYMMDD portion (as a working-zone midnight) rather than
- * shifting it through a timezone. */
+/** UNTIL may be a date or UTC date-time. A date-time is a real instant —
+ * Google normalizes it to UTC (a New-York "ends Aug 26" arrives as
+ * 20260827T035959Z) — so read the working-zone calendar day it falls on. A
+ * bare date is already a calendar date; keep it verbatim. */
 function parseUntilDate(value: string, timeZone: string): number | null {
-  const match = /^(\d{4})(\d{2})(\d{2})(?:T\d{6}Z)?$/.exec(value);
+  const match = /^(\d{4})(\d{2})(\d{2})(?:T(\d{2})(\d{2})(\d{2})Z)?$/.exec(
+    value,
+  );
   if (!match) return null;
   const year = Number(match[1]);
   const month = Number(match[2]);
   const day = Number(match[3]);
-  const date = new TZDate(year, month - 1, day, timeZone);
+  const utc = new Date(Date.UTC(year, month - 1, day));
   if (
-    date.getFullYear() !== year ||
-    date.getMonth() !== month - 1 ||
-    date.getDate() !== day
+    utc.getUTCFullYear() !== year ||
+    utc.getUTCMonth() !== month - 1 ||
+    utc.getUTCDate() !== day
   ) {
     return null;
   }
-  return date.getTime();
+  if (match[4] !== undefined) {
+    const instant = Date.UTC(
+      year,
+      month - 1,
+      day,
+      Number(match[4]),
+      Number(match[5]),
+      Number(match[6]),
+    );
+    const d = zoned(instant, timeZone);
+    return new TZDate(
+      d.getFullYear(),
+      d.getMonth(),
+      d.getDate(),
+      timeZone,
+    ).getTime();
+  }
+  return new TZDate(year, month - 1, day, timeZone).getTime();
 }

--- a/apps/web/src/components/calendar/rrule.ts
+++ b/apps/web/src/components/calendar/rrule.ts
@@ -1,7 +1,10 @@
 // A small, dependency-free RFC5545 recurrence model. We only ever *emit* rules
 // (Google is the source of truth and syncs expanded instances back), so there is
 // no parser here — just a typed model, a string builder, and a human summary.
+import { TZDate } from "@date-fns/tz";
 import { format } from "date-fns";
+
+import { zoned } from "./lib";
 
 export type Freq = "DAILY" | "WEEKLY" | "MONTHLY" | "YEARLY";
 
@@ -47,7 +50,10 @@ export interface Recurrence {
 
 /** Parse the subset of an RFC5545 RRULE that this UI can create and describe.
  * Other recurrence lines (such as EXDATE) do not change the broad summary. */
-export function parseRRule(lines: string[]): Recurrence | null {
+export function parseRRule(
+  lines: string[],
+  timeZone: string,
+): Recurrence | null {
   const line = lines.find((candidate) => candidate.startsWith("RRULE:"));
   if (!line) return null;
 
@@ -90,7 +96,7 @@ export function parseRRule(lines: string[]): Recurrence | null {
     if (count === null) return null;
     end = { kind: "count", count };
   } else if (untilText !== undefined) {
-    const dateMs = parseUntilDate(untilText);
+    const dateMs = parseUntilDate(untilText, timeZone);
     if (dateMs === null) return null;
     end = { kind: "onDate", dateMs };
   }
@@ -98,17 +104,20 @@ export function parseRRule(lines: string[]): Recurrence | null {
   return { freq, interval, byWeekday, end };
 }
 
-/** The RRULE weekday code for a timestamp's calendar day. */
-export function weekdayOf(ms: number): Weekday {
-  return DAY_CODES[new Date(ms).getDay()];
+/** The RRULE weekday code for a timestamp's working-zone calendar day. */
+export function weekdayOf(ms: number, timeZone: string): Weekday {
+  return DAY_CODES[zoned(ms, timeZone).getDay()];
 }
 
 /** A sensible default recurrence for a preset "Custom…" entry point. */
-export function defaultRecurrence(startMs: number): Recurrence {
+export function defaultRecurrence(
+  startMs: number,
+  timeZone: string,
+): Recurrence {
   return {
     freq: "WEEKLY",
     interval: 1,
-    byWeekday: [weekdayOf(startMs)],
+    byWeekday: [weekdayOf(startMs, timeZone)],
     end: { kind: "never" },
   };
 }
@@ -118,8 +127,9 @@ export function sortWeekdays(days: Weekday[]): Weekday[] {
   return WEEKDAYS.filter((d) => days.includes(d));
 }
 
-/** Build the Google `recurrence` array (a single RRULE line) for a model. */
-export function toRRule(r: Recurrence): string[] {
+/** Build the Google `recurrence` array (a single RRULE line) for a model.
+ * `timeZone` is the working zone the end date was picked in. */
+export function toRRule(r: Recurrence, timeZone: string): string[] {
   const parts = [`FREQ=${r.freq}`];
   if (r.interval > 1) {
     parts.push(`INTERVAL=${r.interval}`);
@@ -131,7 +141,7 @@ export function toRRule(r: Recurrence): string[] {
     parts.push(`COUNT=${Math.max(1, r.end.count)}`);
   } else if (r.end.kind === "onDate") {
     // UNTIL is inclusive; pin it to end-of-day UTC so the chosen day counts.
-    const d = new Date(r.end.dateMs);
+    const d = zoned(r.end.dateMs, timeZone);
     const stamp = `${d.getFullYear()}${pad(d.getMonth() + 1)}${pad(
       d.getDate(),
     )}T235959Z`;
@@ -148,7 +158,7 @@ const FREQ_ADVERB: Record<Freq, string> = {
 };
 
 /** Short human description, e.g. "Weekly on Mon, Wed · 5 times". */
-export function summarize(r: Recurrence): string {
+export function summarize(r: Recurrence, timeZone: string): string {
   let base =
     r.interval > 1
       ? `Every ${r.interval} ${FREQ_NOUN[r.freq]}s`
@@ -162,7 +172,7 @@ export function summarize(r: Recurrence): string {
   if (r.end.kind === "count") {
     base += ` · ${r.end.count} time${r.end.count === 1 ? "" : "s"}`;
   } else if (r.end.kind === "onDate") {
-    base += ` · until ${format(r.end.dateMs, "MMM d, yyyy")}`;
+    base += ` · until ${format(zoned(r.end.dateMs, timeZone), "MMM d, yyyy")}`;
   }
   return base;
 }
@@ -191,14 +201,15 @@ function positiveInteger(value: string): number | null {
 }
 
 /** UNTIL may be a date or UTC date-time. The control selects a calendar date,
- * so preserve its YYYYMMDD portion rather than shifting it through a timezone. */
-function parseUntilDate(value: string): number | null {
+ * so preserve its YYYYMMDD portion (as a working-zone midnight) rather than
+ * shifting it through a timezone. */
+function parseUntilDate(value: string, timeZone: string): number | null {
   const match = /^(\d{4})(\d{2})(\d{2})(?:T\d{6}Z)?$/.exec(value);
   if (!match) return null;
   const year = Number(match[1]);
   const month = Number(match[2]);
   const day = Number(match[3]);
-  const date = new Date(year, month - 1, day);
+  const date = new TZDate(year, month - 1, day, timeZone);
   if (
     date.getFullYear() !== year ||
     date.getMonth() !== month - 1 ||

--- a/apps/web/src/components/calendar/time-gutter.tsx
+++ b/apps/web/src/components/calendar/time-gutter.tsx
@@ -10,13 +10,27 @@ interface TimeGutterProps {
   dayStartMs: number;
 }
 
+/** Cached per zone/clock: Intl construction is costly and this renders on
+ * every strip scroll/drag frame. */
+const hourFormatters = new Map<string, Intl.DateTimeFormat>();
+
+function hourFormatter(timeZone: string, use24h: boolean): Intl.DateTimeFormat {
+  const key = `${timeZone}:${use24h}`;
+  let fmt = hourFormatters.get(key);
+  if (!fmt) {
+    fmt = new Intl.DateTimeFormat("en-US", {
+      hour: "numeric",
+      timeZone,
+      hour12: !use24h,
+    });
+    hourFormatters.set(key, fmt);
+  }
+  return fmt;
+}
+
 export function TimeGutter({ timeZone, dayStartMs }: TimeGutterProps) {
   const { use24h } = usePreferences();
-  const fmt = new Intl.DateTimeFormat("en-US", {
-    hour: "numeric",
-    timeZone,
-    hour12: !use24h,
-  });
+  const fmt = hourFormatter(timeZone, use24h);
   return (
     <div className="relative h-full">
       {HOURS.map((hour) => (

--- a/apps/web/src/components/calendar/time-strip.tsx
+++ b/apps/web/src/components/calendar/time-strip.tsx
@@ -487,6 +487,18 @@ export const TimeStrip = forwardRef<TimeStripHandle, TimeStripProps>(
 
     // On first entry to a current day/week, put now comfortably below the
     // sticky header. This guard deliberately prevents event/sync rerenders from
+    // The working zone can resolve a beat after mount (the preferences query
+    // lands once auth attaches) or change from settings: re-arm the initial
+    // now-scroll so the strip re-parks against the new zone's own now-line.
+    // Runs before the scroll effect below (same phase, source order), and the
+    // userInteractedRef guard there keeps a deliberate scroll untouched.
+    const parkedZoneRef = useRef(timeZone);
+    useLayoutEffect(() => {
+      if (parkedZoneRef.current === timeZone) return;
+      parkedZoneRef.current = timeZone;
+      didInitialNowScroll.current = false;
+    }, [timeZone]);
+
     // moving a user's scroll position. Only auto-scroll when today is on the
     // strip, so paging to an unrelated week doesn't yank the scroll position.
     useLayoutEffect(() => {
@@ -517,11 +529,25 @@ export const TimeStrip = forwardRef<TimeStripHandle, TimeStripProps>(
         onPointerDown={cancelPendingTodayPulse}
         onTouchStart={cancelPendingTodayPulse}
         onWheel={cancelPendingTodayPulse}
-        className="group/strip flex min-h-0 flex-1 overflow-auto overscroll-x-contain bg-calendar-header [overflow-anchor:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
-        style={{ scrollSnapType: "x mandatory", scrollPaddingLeft: GUTTER_TOTAL }}
+        className="group/strip flex min-h-0 flex-1 overflow-auto overscroll-x-contain bg-background [overflow-anchor:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+        style={{
+          scrollSnapType: "x mandatory",
+          scrollPaddingLeft: GUTTER_TOTAL,
+          // The scroller's own surface is what an elastic overscroll reveals
+          // (it doesn't travel with the bouncing content): header-colored on
+          // top so a downward tug reads as more header, page-colored below so
+          // scrolling past the last hour reads as more grid.
+          backgroundImage:
+            "linear-gradient(to bottom, var(--calendar-header) 0%, var(--calendar-header) 50%, var(--background) 50%)",
+        }}
       >
+        {/* Both columns opt out of the flex cross-axis stretch (`h-max` with a
+            `min-h-full` floor): stretched, they'd be only as tall as the
+            scroller's viewport, and the sticky day header would run out of
+            containing block a third of the way down the grid and scroll away.
+            Content-height columns give `sticky top-0` the full scroll range. */}
         <div
-          className="sticky left-0 z-[60] shrink-0 overflow-x-clip bg-background"
+          className="sticky left-0 z-[60] h-max min-h-full shrink-0 overflow-x-clip bg-background"
           style={{ flex: `0 0 ${GUTTER_TOTAL}px`, width: GUTTER_TOTAL }}
         >
           <GutterColumn
@@ -535,7 +561,7 @@ export const TimeStrip = forwardRef<TimeStripHandle, TimeStripProps>(
           />
         </div>
         <div
-          className="flex shrink-0 flex-col"
+          className="flex h-max min-h-full shrink-0 flex-col"
           style={{
             flex: `0 0 calc(${days.length} * (100% - ${GUTTER_TOTAL}px) / ${columns})`,
           }}
@@ -588,6 +614,10 @@ export const TimeStrip = forwardRef<TimeStripHandle, TimeStripProps>(
             style={{
               gridTemplateColumns: dayColsTemplate(days.length),
               height: TIME_GRID_BOTTOM_SPACER_HEIGHT,
+              // Let the day dividers dissolve instead of stopping dead, so an
+              // overscroll past the last hour trails off smoothly. The masked
+              // bg fades into the scroller's identical bottom color.
+              maskImage: "linear-gradient(to bottom, black, transparent)",
             }}
           >
             {days.map((day) => (

--- a/apps/web/src/components/calendar/time-strip.tsx
+++ b/apps/web/src/components/calendar/time-strip.tsx
@@ -11,6 +11,7 @@ import {
   useState,
 } from "react";
 
+import { usePreferences } from "@/components/workspace/preferences-context";
 import { DayColumn } from "./day-column";
 import { GutterColumn } from "./gutter-column";
 import {
@@ -114,6 +115,7 @@ export const TimeStrip = forwardRef<TimeStripHandle, TimeStripProps>(
     const centerAtPctRef = useRef<number | "now" | null>(null);
     const nowLayoutRef = useRef<NowIndicatorLayout | null>(null);
     const userInteractedRef = useRef(false);
+    const { timeZone } = usePreferences();
     const [now, setNow] = useState(() => Date.now());
     const [visibleStartIdx, setVisibleStartIdx] = useState(anchorIndex);
     const people = useQuery(api.domains.people.queries.listPeople) ?? NO_CONTACTS;
@@ -478,7 +480,7 @@ export const TimeStrip = forwardRef<TimeStripHandle, TimeStripProps>(
       visibleAllDayLaneCount,
       allDayExpanded,
     );
-    const nowLayout = getNowIndicatorLayout(days, now);
+    const nowLayout = getNowIndicatorLayout(days, now, timeZone);
     // Expose the latest layout to the imperative scroll helpers (which run
     // outside render) without threading it through their dependency arrays.
     nowLayoutRef.current = nowLayout;

--- a/apps/web/src/components/calendar/use-event-drag.ts
+++ b/apps/web/src/components/calendar/use-event-drag.ts
@@ -5,8 +5,15 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 
 import { useDock } from "@/components/workspace/dock-context";
+import { usePreferences } from "@/components/workspace/preferences-context";
 
-import { type CalendarEvent, editableEventId, MS_PER_DAY, SNAP_MS } from "./lib";
+import {
+  type CalendarEvent,
+  editableEventId,
+  MS_PER_DAY,
+  SNAP_MS,
+  zoned,
+} from "./lib";
 import { useEventCapabilities } from "./permissions";
 
 /** How a card is being manipulated: relocated whole, or one edge dragged. */
@@ -81,8 +88,14 @@ export function useEventDrag(
   days: Date[],
 ): UseEventDrag {
   const { open } = useDock();
+  const { timeZone } = usePreferences();
   const updateEventTime = useAction(api.domains.calendar.service.updateEventTime);
   const capabilitiesOf = useEventCapabilities();
+
+  // Read at use time through a ref, like `days`, so a preference change never
+  // re-binds the gesture's window listeners mid-drag.
+  const timeZoneRef = useRef(timeZone);
+  timeZoneRef.current = timeZone;
 
   const [overrides, setOverrides] = useState<Record<string, OverrideTimes>>({});
   const [draggingId, setDraggingId] = useState<string | null>(null);
@@ -202,8 +215,11 @@ export function useEventDrag(
         return { startMs, endMs: startMs + s.durationMs };
       }
 
-      // Resize stays on the event's own day.
-      const dayStart = startOfDay(new Date(origStart)).getTime();
+      // Resize stays on the event's own day — cut in the working zone, like
+      // the strip's day columns the move path reads from.
+      const dayStart = startOfDay(
+        zoned(origStart, timeZoneRef.current),
+      ).getTime();
       const dayEnd = dayStart + MS_PER_DAY;
       const rawPointer = dayStart + (clientY - rect.top) * msPerPx;
       const pointer = clamp(snap(rawPointer, dayStart), dayStart, dayEnd);
@@ -239,9 +255,9 @@ export function useEventDrag(
         eventId: editableEventId(id),
         startMs: times.startMs,
         endMs: times.endMs,
-        // Browser zone, not the timezone preference — the drag's wall-clock
-        // math is browser-local, and the zone must match how it was composed.
-        timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+        // The working zone: the strip's day columns (which the drag math
+        // reads its day starts from) are cut in it.
+        timeZone: timeZoneRef.current,
       }).catch((error: unknown) => {
         // Roll the card back to its synced position and surface the failure.
         pendingRef.current.delete(id);

--- a/apps/web/src/components/calendar/working-zone.test.ts
+++ b/apps/web/src/components/calendar/working-zone.test.ts
@@ -1,0 +1,107 @@
+// @ts-expect-error Bun supplies its test module at runtime; the web app's
+// TypeScript config intentionally includes browser globals only.
+import { describe, expect, test } from "bun:test";
+import { TZDate } from "@date-fns/tz";
+import { format } from "date-fns";
+
+import { getNowIndicatorLayout } from "./now-indicator";
+import { toRRule, weekdayOf } from "./rrule";
+import { pageDays, pageStart, stripDays, zoned } from "./lib";
+
+process.env.SKIP_ENV_VALIDATION = "1";
+const { toEventTimes } = await import("./event-form");
+
+// 2026-03-14T02:30Z: 21:30 Sat in New York (EST), 16:30 Sat in Kiritimati of
+// the NEXT day (UTC+14 → Sat 16:30? no: +14 → 16:30 on the 14th). Use an
+// instant that straddles a date line: 2026-08-26T12:00Z is Wed Aug 26 in both
+// hemispheres except UTC+14 where it is 02:00 Thu Aug 27.
+const STRADDLE_MS = Date.parse("2026-08-26T12:00:00.000Z");
+const NY = "America/New_York";
+const KIRITIMATI = "Pacific/Kiritimati"; // UTC+14, no DST
+
+describe("working-zone day cuts", () => {
+  test("the same instant lands on different calendar days per zone", () => {
+    expect(format(zoned(STRADDLE_MS, NY), "yyyy-MM-dd")).toBe("2026-08-26");
+    expect(format(zoned(STRADDLE_MS, KIRITIMATI), "yyyy-MM-dd")).toBe(
+      "2026-08-27",
+    );
+  });
+
+  test("pageStart cuts the week at the working zone's midnight", () => {
+    const weekNy = pageStart("week", zoned(STRADDLE_MS, NY), 1);
+    const weekKi = pageStart("week", zoned(STRADDLE_MS, KIRITIMATI), 1);
+    // Both are Mondays at 00:00 in their own zone…
+    expect(format(weekNy, "EEE HH:mm")).toBe("Mon 00:00");
+    expect(format(weekKi, "EEE HH:mm")).toBe("Mon 00:00");
+    // …but different instants (Kiritimati's Monday midnight comes 18h earlier
+    // than New York's on this date: UTC+14 vs UTC-4).
+    expect(weekNy.getTime() - weekKi.getTime()).toBe(18 * 60 * 60 * 1000);
+  });
+
+  test("stripDays yields consecutive working-zone midnights", () => {
+    const anchor = pageStart("day", zoned(STRADDLE_MS, NY), 1);
+    const days = stripDays(anchor, 3, 1);
+    for (const day of days) {
+      expect(format(day, "HH:mm")).toBe("00:00");
+      expect((day as TZDate).timeZone).toBe(NY);
+    }
+  });
+
+  test("month pages carry the zone through the 6x7 grid", () => {
+    const start = pageStart("month", zoned(STRADDLE_MS, KIRITIMATI), 1);
+    const days = pageDays("month", start, 1);
+    expect(days).toHaveLength(42);
+    expect(format(days[0], "HH:mm")).toBe("00:00");
+    expect((days[41] as TZDate).timeZone).toBe(KIRITIMATI);
+  });
+});
+
+describe("working-zone now indicator", () => {
+  test("finds today's column among zone-cut days and positions by zone clock", () => {
+    const anchor = pageStart("day", zoned(STRADDLE_MS, KIRITIMATI), 1);
+    const days = stripDays(anchor, 3, 0);
+    const layout = getNowIndicatorLayout(days, STRADDLE_MS, KIRITIMATI);
+    expect(layout?.today).not.toBeNull();
+    // 02:00 in Kiritimati → 2/24 of the way down the day.
+    expect(layout?.topPct).toBeCloseTo((2 / 24) * 100, 5);
+    // The same instant read in New York sits at 08:00 (EDT, UTC-4).
+    const layoutNy = getNowIndicatorLayout(days, STRADDLE_MS, NY);
+    expect(layoutNy?.topPct).toBeCloseTo((8 / 24) * 100, 5);
+  });
+});
+
+describe("working-zone event composition", () => {
+  test("all-day boundaries follow the working zone's calendar date", () => {
+    const value = {
+      startMs: STRADDLE_MS,
+      endMs: STRADDLE_MS,
+      allDay: true,
+    } as Parameters<typeof toEventTimes>[0];
+    // Aug 26 in New York…
+    expect(toEventTimes(value, NY).startMs).toBe(
+      Date.parse("2026-08-26T00:00:00.000Z"),
+    );
+    // …but Aug 27 across the date line.
+    expect(toEventTimes(value, KIRITIMATI).startMs).toBe(
+      Date.parse("2026-08-27T00:00:00.000Z"),
+    );
+  });
+
+  test("recurrence weekday and UNTIL stamp read the working zone", () => {
+    // Thursday in Kiritimati, Wednesday in New York.
+    expect(weekdayOf(STRADDLE_MS, KIRITIMATI)).toBe("TH");
+    expect(weekdayOf(STRADDLE_MS, NY)).toBe("WE");
+
+    const rule = (tz: string) =>
+      toRRule(
+        {
+          freq: "DAILY",
+          interval: 1,
+          end: { kind: "onDate", dateMs: STRADDLE_MS },
+        },
+        tz,
+      )[0];
+    expect(rule(NY)).toContain("UNTIL=20260826T235959Z");
+    expect(rule(KIRITIMATI)).toContain("UNTIL=20260827T235959Z");
+  });
+});

--- a/apps/web/src/components/calendar/working-zone.test.ts
+++ b/apps/web/src/components/calendar/working-zone.test.ts
@@ -101,7 +101,9 @@ describe("working-zone event composition", () => {
         },
         tz,
       )[0];
-    expect(rule(NY)).toContain("UNTIL=20260826T235959Z");
-    expect(rule(KIRITIMATI)).toContain("UNTIL=20260827T235959Z");
+    // End of the chosen day in each zone, stamped as a real UTC instant:
+    // 23:59:59 EDT Aug 26 = 03:59:59Z Aug 27; 23:59:59 +14 Aug 27 = 09:59:59Z.
+    expect(rule(NY)).toContain("UNTIL=20260827T035959Z");
+    expect(rule(KIRITIMATI)).toContain("UNTIL=20260827T095959Z");
   });
 });

--- a/apps/web/src/components/workspace/assistant-panel.tsx
+++ b/apps/web/src/components/workspace/assistant-panel.tsx
@@ -40,6 +40,7 @@ import {
   AssistantProposalCard,
   type AssistantAction,
 } from "./assistant-proposal-card";
+import { usePreferences } from "./preferences-context";
 
 type AssistantMessage = Doc<"assistantMessages">;
 
@@ -121,6 +122,7 @@ export function AssistantPanel({
   const [sending, setSending] = useState(false);
   const [pendingSend, setPendingSend] = useState<PendingSend | null>(null);
   const sendMessage = useAction(api.domains.assistant.loop.sendMessage);
+  const { timeZone } = usePreferences();
   const reduceMotion = useReducedMotion();
   const sendGooFilterId = useId().replace(/[:]/g, "");
 
@@ -275,10 +277,10 @@ export function AssistantPanel({
         threadId: threadId ?? undefined,
         text: trimmed,
         // The backend must never guess these — every relative date the model
-        // resolves depends on them. The browser zone, not the timezone
-        // preference: "tomorrow" must mean tomorrow where the user is, on the
-        // grid they're looking at (which renders browser-local).
-        timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+        // resolves depends on them. The working zone: it is the zone of the
+        // grid the user is looking at, so "tomorrow at noon" lands where
+        // they expect.
+        timeZone,
       });
       onThreadChange(result.threadId);
     } catch (error: unknown) {

--- a/apps/web/src/components/workspace/availability-edit-context.tsx
+++ b/apps/web/src/components/workspace/availability-edit-context.tsx
@@ -10,6 +10,7 @@ import {
   createContext,
   useCallback,
   useContext,
+  useEffect,
   useMemo,
   useState,
   type ReactNode,
@@ -130,6 +131,19 @@ export function AvailabilityEditProvider({ children }: { children: ReactNode }) 
     page !== null &&
     page.timeZone === workingZone &&
     overrides !== undefined;
+
+  // A working-zone change mid-paint (settings on another tab or device) would
+  // desync the grid's date keys from the page's saved zone; rather than sit
+  // inert behind the edit bar's loading state forever, close the session and
+  // say why.
+  useEffect(() => {
+    if (!editing || !page || page.timeZone === workingZone) return;
+    setEditingState(false);
+    toast.error("Availability editing closed", {
+      description:
+        "Your working time zone changed. Reopen to continue in the new zone.",
+    });
+  }, [editing, page, workingZone]);
 
   const intervalsForDay = useCallback(
     (day: Date): DayAvailability => {

--- a/apps/web/src/components/workspace/availability-edit-context.tsx
+++ b/apps/web/src/components/workspace/availability-edit-context.tsx
@@ -17,6 +17,7 @@ import {
 import { toast } from "sonner";
 
 import { MS_PER_MINUTE } from "@/components/calendar/lib";
+import { usePreferences } from "./preferences-context";
 
 /** A day's availability span with its live save state, so the grid can shimmer a
  * block that is still being written and paint it solid once it lands. */
@@ -53,10 +54,9 @@ const AvailabilityEditContext = createContext<AvailabilityEditValue | null>(
 
 const NO_ARGS = {} as const;
 
-/** `dateKey` as the day reads locally. Painting is only enabled while the
- * page's zone equals this browser's (the `ready` gate below), so the local
- * key is the page's key — with a foreign preferred zone, edit mode stays
- * unavailable rather than authoring keys in the wrong zone. */
+/** `dateKey` as the day reads in its own zone. Grid days are working-zone
+ * TZDates, and the `ready` gate below requires the page's zone to equal the
+ * working zone — so this key is always the page's key. */
 function dayKey(day: Date): string {
   return format(day, "yyyy-MM-dd");
 }
@@ -120,11 +120,15 @@ export function AvailabilityEditProvider({ children }: { children: ReactNode }) 
   }, [overrides]);
 
   const rules = page?.rules ?? [];
-  const browserTimeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+  // Painting authors date keys and wall-clock minutes off the grid, which is
+  // cut in the working zone — so the page must be saved in that same zone.
+  // The availability panel persists the working zone before entering edit
+  // mode, so this holds by construction after any save.
+  const { timeZone: workingZone } = usePreferences();
   const ready =
     page !== undefined &&
     page !== null &&
-    page.timeZone === browserTimeZone &&
+    page.timeZone === workingZone &&
     overrides !== undefined;
 
   const intervalsForDay = useCallback(

--- a/apps/web/src/components/workspace/availability-panel.tsx
+++ b/apps/web/src/components/workspace/availability-panel.tsx
@@ -311,6 +311,10 @@ function AvailabilityForm({
   const openDayCount = WEEKDAYS.filter(
     ({ weekday }) => rows[weekday]?.enabled,
   ).length;
+  // Saving rewrites the page into the current working zone; published hours
+  // and painted days are wall-clock-relative to it, so a zone change must be
+  // visible before the user re-bases them.
+  const zoneChanged = page !== null && page.timeZone !== timeZone;
   const slugReady =
     normalized.length >= 3 && (slugUnchanged || check?.available === true);
   const canSave = slugReady && rules.length > 0 && !saving;
@@ -675,7 +679,9 @@ function AvailabilityForm({
                 <span className="truncate text-xs text-muted-foreground">
                   {page === null
                     ? "Save your link first to override single days"
-                    : "Save these settings, then paint individual days"}
+                    : zoneChanged
+                      ? `Saving moves your published hours to ${timeZone.replace(/_/g, " ")} time`
+                      : "Save these settings, then paint individual days"}
                 </span>
               </span>
               <HugeiconsIcon
@@ -753,6 +759,13 @@ function AvailabilityForm({
                 />
               </div>
             </div>
+
+            {zoneChanged && (
+              <p className="px-2 text-xs text-muted-foreground">
+                Your working time zone changed — saving moves these hours and
+                any painted days to {timeZone.replace(/_/g, " ")} time.
+              </p>
+            )}
 
             <div className="flex items-center gap-2">
               <label className="flex min-w-0 flex-1 items-center gap-2.5">

--- a/apps/web/src/components/workspace/availability-panel.tsx
+++ b/apps/web/src/components/workspace/availability-panel.tsx
@@ -208,11 +208,6 @@ function AvailabilityForm({
   const upsert = useMutation(api.domains.booking.mutations.upsertBookingPage);
   const { setEditing } = useAvailabilityEdit();
   const { timeZone } = usePreferences();
-  // Day painting authors date keys in the browser's zone, so it's only
-  // available while the page's zone (the timezone preference) matches it —
-  // see the `ready` gate in availability-edit-context.
-  const zoneMismatch =
-    timeZone !== Intl.DateTimeFormat().resolvedOptions().timeZone;
   const reduce = useReducedMotion();
   const initial = page ?? defaults;
   const lastInitial = useRef(initial);
@@ -403,9 +398,10 @@ function AvailabilityForm({
   };
 
   const openDateEditor = async () => {
-    if (page === null || zoneMismatch) return;
-    // Persist the draft and its zone before the calendar starts authoring
-    // date keys and wall-clock minutes against it.
+    if (page === null) return;
+    // Persist the draft in the working zone before the calendar starts
+    // authoring date keys and wall-clock minutes against it — this is what
+    // guarantees the edit context's page-zone gate holds.
     if (await persist(false)) setEditing(true);
   };
 
@@ -665,7 +661,7 @@ function AvailabilityForm({
                 needs a saved page, so it's gated until one exists. */}
             <button
               type="button"
-              disabled={page === null || !canSave || zoneMismatch}
+              disabled={page === null || !canSave}
               onClick={() => void openDateEditor()}
               className="group flex items-center gap-3 rounded-2xl bg-muted/60 px-3 py-2.5 text-left outline-none transition-colors hover:bg-muted focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:bg-muted/60"
             >
@@ -677,11 +673,9 @@ function AvailabilityForm({
               <span className="flex min-w-0 flex-1 flex-col">
                 <span className="text-sm font-medium">Set specific dates</span>
                 <span className="truncate text-xs text-muted-foreground">
-                  {zoneMismatch
-                    ? `Painting needs your time zone preference to match this device (${timeZone})`
-                    : page === null
-                      ? "Save your link first to override single days"
-                      : "Save these settings, then paint individual days"}
+                  {page === null
+                    ? "Save your link first to override single days"
+                    : "Save these settings, then paint individual days"}
                 </span>
               </span>
               <HugeiconsIcon

--- a/apps/web/src/components/workspace/booking-request-panel.tsx
+++ b/apps/web/src/components/workspace/booking-request-panel.tsx
@@ -10,6 +10,9 @@ import { Button } from "@qali/ui/components/button";
 import { Spinner } from "@qali/ui/components/spinner";
 import { useAction, useMutation, useQuery } from "convex/react";
 import { format, formatDistanceToNowStrict } from "date-fns";
+
+import { zoned } from "@/components/calendar/lib";
+import { usePreferences } from "./preferences-context";
 import { motion, useReducedMotion } from "motion/react";
 import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
@@ -66,12 +69,13 @@ function useBookingDecision(onDone: (booking: Booking) => void) {
   return { decide, busy };
 }
 
-/** "Mon, Aug 3 · 10:00 – 10:30", in the host's own zone. */
-export function bookingTimeLabel(booking: Booking): string {
-  return `${format(booking.startMs, "EEE, MMM d")} · ${format(
-    booking.startMs,
+/** "Mon, Aug 3 · 10:00 – 10:30", in the host's working zone. */
+export function bookingTimeLabel(booking: Booking, timeZone: string): string {
+  const start = zoned(booking.startMs, timeZone);
+  return `${format(start, "EEE, MMM d")} · ${format(
+    start,
     "HH:mm",
-  )} – ${format(booking.endMs, "HH:mm")}`;
+  )} – ${format(zoned(booking.endMs, timeZone), "HH:mm")}`;
 }
 
 export function BookingRequestPanel({
@@ -88,6 +92,7 @@ export function BookingRequestPanel({
     endMs: snapshot.endMs + 1,
   });
   const booking = live?.find((b) => b._id === snapshot._id) ?? snapshot;
+  const { timeZone } = usePreferences();
   const { decide, busy } = useBookingDecision(onClose);
   const activeDecision = busy?.bookingId === booking._id ? busy.decision : null;
 
@@ -99,7 +104,7 @@ export function BookingRequestPanel({
             {booking.requesterName}
           </p>
           <p className="text-xs text-muted-foreground">
-            {bookingTimeLabel(booking)}
+            {bookingTimeLabel(booking, timeZone)}
           </p>
         </div>
         <button
@@ -253,6 +258,7 @@ function RequestCard({
   onDecide: (decision: BookingDecision) => void;
 }) {
   const reduce = useReducedMotion();
+  const { timeZone } = usePreferences();
   const noteRef = useRef<HTMLParagraphElement>(null);
   const [expanded, setExpanded] = useState(false);
   const [canExpand, setCanExpand] = useState<boolean>();
@@ -305,7 +311,7 @@ function RequestCard({
             strokeWidth={2}
             className="size-3.5 shrink-0 text-muted-foreground"
           />
-          <span className="truncate">{bookingTimeLabel(booking)}</span>
+          <span className="truncate">{bookingTimeLabel(booking, timeZone)}</span>
         </p>
         <p className="pl-5 text-[11px] text-muted-foreground">
           Requester's timezone: {booking.timeZone.replace(/_/g, " ")}

--- a/apps/web/src/components/workspace/booking-request-panel.tsx
+++ b/apps/web/src/components/workspace/booking-request-panel.tsx
@@ -11,7 +11,7 @@ import { Spinner } from "@qali/ui/components/spinner";
 import { useAction, useMutation, useQuery } from "convex/react";
 import { format, formatDistanceToNowStrict } from "date-fns";
 
-import { zoned } from "@/components/calendar/lib";
+import { timePattern, zoned } from "@/components/calendar/lib";
 import { usePreferences } from "./preferences-context";
 import { motion, useReducedMotion } from "motion/react";
 import { useEffect, useRef, useState } from "react";
@@ -69,13 +69,18 @@ function useBookingDecision(onDone: (booking: Booking) => void) {
   return { decide, busy };
 }
 
-/** "Mon, Aug 3 · 10:00 – 10:30", in the host's working zone. */
-export function bookingTimeLabel(booking: Booking, timeZone: string): string {
+/** "Mon, Aug 3 · 10:00 AM – 10:30 AM", in the host's working zone and clock. */
+export function bookingTimeLabel(
+  booking: Booking,
+  timeZone: string,
+  use24h: boolean,
+): string {
+  const time = timePattern(use24h);
   const start = zoned(booking.startMs, timeZone);
   return `${format(start, "EEE, MMM d")} · ${format(
     start,
-    "HH:mm",
-  )} – ${format(zoned(booking.endMs, timeZone), "HH:mm")}`;
+    time,
+  )} – ${format(zoned(booking.endMs, timeZone), time)}`;
 }
 
 export function BookingRequestPanel({
@@ -92,7 +97,7 @@ export function BookingRequestPanel({
     endMs: snapshot.endMs + 1,
   });
   const booking = live?.find((b) => b._id === snapshot._id) ?? snapshot;
-  const { timeZone } = usePreferences();
+  const { timeZone, use24h } = usePreferences();
   const { decide, busy } = useBookingDecision(onClose);
   const activeDecision = busy?.bookingId === booking._id ? busy.decision : null;
 
@@ -104,7 +109,7 @@ export function BookingRequestPanel({
             {booking.requesterName}
           </p>
           <p className="text-xs text-muted-foreground">
-            {bookingTimeLabel(booking, timeZone)}
+            {bookingTimeLabel(booking, timeZone, use24h)}
           </p>
         </div>
         <button
@@ -258,7 +263,7 @@ function RequestCard({
   onDecide: (decision: BookingDecision) => void;
 }) {
   const reduce = useReducedMotion();
-  const { timeZone } = usePreferences();
+  const { timeZone, use24h } = usePreferences();
   const noteRef = useRef<HTMLParagraphElement>(null);
   const [expanded, setExpanded] = useState(false);
   const [canExpand, setCanExpand] = useState<boolean>();
@@ -311,7 +316,7 @@ function RequestCard({
             strokeWidth={2}
             className="size-3.5 shrink-0 text-muted-foreground"
           />
-          <span className="truncate">{bookingTimeLabel(booking, timeZone)}</span>
+          <span className="truncate">{bookingTimeLabel(booking, timeZone, use24h)}</span>
         </p>
         <p className="pl-5 text-[11px] text-muted-foreground">
           Requester's timezone: {booking.timeZone.replace(/_/g, " ")}

--- a/apps/web/src/components/workspace/bottom-island.tsx
+++ b/apps/web/src/components/workspace/bottom-island.tsx
@@ -17,7 +17,7 @@ import {
 import { cn } from "@qali/ui/lib/utils";
 import { useQuery } from "convex/react";
 import { AnimatePresence, motion, useReducedMotion } from "motion/react";
-import { useEffect, useRef, useState } from "react";
+import { lazy, Suspense, useEffect, useRef, useState } from "react";
 
 import { EventCreate } from "@/components/calendar/event-create";
 import { EventDetail } from "@/components/calendar/event-detail";
@@ -34,12 +34,22 @@ import { useAvailabilityEdit } from "./availability-edit-context";
 import { AvailabilityPanel } from "./availability-panel";
 import { BookingRequestPanel } from "./booking-request-panel";
 import { useDock, type DockView } from "./dock-context";
-import { SettingsPanel } from "./settings-panel";
 import { UserAvatar } from "./user-avatar";
 import { useSyncNow } from "./use-sync-now";
 
 const MAX_TIMEOUT_MS = 2_147_000_000;
 const AVAILABILITY_PREFETCH_GRACE_MS = 10_000;
+
+/** Settings is the dock's heaviest panel by far, so it loads as its own chunk
+ * instead of riding in the dock's synchronous module graph (the assistant
+ * panel next door does the same). The dock warms it during idle time right
+ * after mount, so by the time anyone reaches Settings — via the account panel
+ * or the nav gear — the chunk is already resolved and Suspense never shows. */
+const loadSettingsPanel = () =>
+  import("./settings-panel").then((m) => ({ default: m.SettingsPanel }));
+
+// Module scope so React keeps the resolved value across dock open/close.
+const SettingsPanelLazy = lazy(loadSettingsPanel);
 
 /** Each view gets its own width so the shell visibly adapts to what it holds.
  * Padding is deliberately not part of this — every panel shares one inset.
@@ -62,11 +72,37 @@ function cornerRadius(view: DockView | null): number {
   return view ? 20 : 28;
 }
 
+/** Warm the settings panel's one cold query from the dock itself: the
+ * subscription lives for as long as either panel is open, so the handoff
+ * never depends on panel-swap animation overlap keeping a watcher mounted.
+ * It renders nothing and lives outside the island's `layout` node so the
+ * query resolving mid-open never re-measures the in-flight spring. */
+function ConnectionsWarmup({ active }: { active: boolean }) {
+  useStableQuery(
+    api.domains.calendar.queries.listConnections,
+    active ? {} : "skip",
+  );
+  return null;
+}
+
 export function BottomIsland() {
   const { view, viewId, direction, open, close, openCreate } = useDock();
   const { editing, setEditing, ready: availabilityEditReady } =
     useAvailabilityEdit();
   const reduce = useReducedMotion();
+
+  // Warm the settings chunk once the page is idle so a cold open never
+  // suspends. Fire-and-forget: a failed fetch just falls back to Suspense.
+  useEffect(() => {
+    const warm = () => void loadSettingsPanel().catch(() => {});
+    if (typeof window.requestIdleCallback === "function") {
+      const id = window.requestIdleCallback(warm);
+      return () => window.cancelIdleCallback(id);
+    }
+    const id = window.setTimeout(warm, 1_500);
+    return () => window.clearTimeout(id);
+  }, []);
+
   const availabilityOpen = view?.kind === "availability";
   const [availabilityIntentVersion, setAvailabilityIntentVersion] = useState(0);
   const [availabilityRequested, setAvailabilityRequested] = useState(false);
@@ -76,13 +112,6 @@ export function BottomIsland() {
     availabilityIntentVersion > 0;
   // This stays live for the dock badge and incoming-request calendar blocks.
   const pendingBookings = useQuery(api.domains.booking.queries.listPendingBookings);
-  // Warm the settings panel's one cold query from the dock itself: the
-  // subscription lives for as long as either panel is open, so the handoff
-  // never depends on panel-swap animation overlap keeping a watcher mounted.
-  useStableQuery(
-    api.domains.calendar.queries.listConnections,
-    view?.kind === "account" || view?.kind === "settings" ? {} : "skip",
-  );
   // Warm settings on interaction intent so the dock knows its final content
   // height before its spring begins. Retain them briefly after close for a
   // smooth reopen, then release both subscriptions.
@@ -227,6 +256,9 @@ export function BottomIsland() {
 
   return (
     <>
+      <ConnectionsWarmup
+        active={view?.kind === "account" || view?.kind === "settings"}
+      />
       {/* Settings is the one view that dims the calendar behind it — a
           deliberate exception to the dock's no-scrim rule: the wide sheet
           covers enough of the grid that stray taps should dismiss, not act.
@@ -329,10 +361,18 @@ export function BottomIsland() {
                   onOpenSettings={() => open({ kind: "settings" })}
                 />
               ) : view?.kind === "settings" ? (
-                <SettingsPanel
-                  initialSection={view.section}
-                  onClose={closeCurrent}
-                />
+                <Suspense
+                  fallback={
+                    <div className="flex h-96 items-center justify-center">
+                      <Spinner className="size-5" />
+                    </div>
+                  }
+                >
+                  <SettingsPanelLazy
+                    initialSection={view.section}
+                    onClose={closeCurrent}
+                  />
+                </Suspense>
               ) : view?.kind === "availability" ? (
                 <AvailabilityPanel
                   key={availabilityInstance.current}

--- a/apps/web/src/components/workspace/dock-context.tsx
+++ b/apps/web/src/components/workspace/dock-context.tsx
@@ -12,8 +12,10 @@ import type { EventPrefill } from "@/components/calendar/event-create";
 import {
   DEFAULT_EVENT_DURATION_MS,
   nextFreeSlot,
+  zonedNow,
   type CalendarEvent,
 } from "@/components/calendar/lib";
+import { usePreferences } from "@/components/workspace/preferences-context";
 import { startOfDay } from "date-fns";
 import type { Booking } from "@/components/workspace/booking-request-panel";
 import type { SettingsSection } from "@/components/workspace/settings-panel";
@@ -85,6 +87,7 @@ interface DockContextValue {
 const DockContext = createContext<DockContextValue | null>(null);
 
 export function DockProvider({ children }: { children: ReactNode }) {
+  const { timeZone } = usePreferences();
   // View and direction move together so the exiting and entering content always
   // agree on which way they are travelling.
   const [state, setState] = useState<{ view: DockView | null; direction: number }>({
@@ -107,7 +110,8 @@ export function DockProvider({ children }: { children: ReactNode }) {
 
   const openCreate = useCallback(() => {
     const seed = createSeedRef.current;
-    const dayStartMs = seed?.dayStartMs ?? startOfDay(Date.now()).getTime();
+    const dayStartMs =
+      seed?.dayStartMs ?? startOfDay(zonedNow(timeZone)).getTime();
     const range = nextFreeSlot(
       dayStartMs,
       seed?.events ?? [],
@@ -115,7 +119,7 @@ export function DockProvider({ children }: { children: ReactNode }) {
       DEFAULT_EVENT_DURATION_MS,
     );
     open({ kind: "create", ...range });
-  }, [open]);
+  }, [open, timeZone]);
 
   // A ref, like the create seed: the calendar registers on mount and callers
   // only read it when they fire, so no render needs to track it.

--- a/apps/web/src/components/workspace/preferences-context.tsx
+++ b/apps/web/src/components/workspace/preferences-context.tsx
@@ -26,10 +26,10 @@ interface PreferencesValue {
   weekStartsOn: WeekStart;
   use24h: boolean;
   defaultView: CalendarView;
-  /** The zone the booking page's hours are published in. Event writes and
-   * grid rendering deliberately stay in the browser's zone — event times are
-   * composed in browser-local wall clock, and a different anchor would drift
-   * recurrences (see the note by TIMEZONES in calendar/lib.ts). */
+  /** The WORKING zone: the calendar renders, composes, and labels every
+   * time in it — day cuts, gutter hours, wheel pickers, event writes, the
+   * booking page's hours, and assistant date resolution. Defaults to the
+   * browser's zone when no preference is stored. */
   timeZone: string;
   defaultCalendarId: RawPreferences["defaultCalendarId"];
   /** The stored fields as-is, for UI that distinguishes "automatic" from set. */

--- a/apps/web/src/components/workspace/preferences-context.tsx
+++ b/apps/web/src/components/workspace/preferences-context.tsx
@@ -38,15 +38,6 @@ interface PreferencesValue {
 
 const PreferencesContext = createContext<PreferencesValue | null>(null);
 
-/** Everything "automatic": the fallback when nothing is stored or readable. */
-const EMPTY_RAW: RawPreferences = {
-  timeZone: undefined,
-  weekStartsOn: undefined,
-  timeFormat: undefined,
-  defaultView: undefined,
-  defaultCalendarId: undefined,
-};
-
 function resolve(raw: RawPreferences): PreferencesValue {
   return {
     weekStartsOn: raw.weekStartsOn ?? WEEK_STARTS_ON,
@@ -60,12 +51,13 @@ function resolve(raw: RawPreferences): PreferencesValue {
 
 /**
  * Loads the user's preferences once for the workspace. The very first paint
- * waits for the query (piggybacking on the auth-loading skeleton moment) so
- * the calendar mounts with the right default view and week shape. After that
- * the workspace NEVER unmounts on this query: a transient `null` (the query
- * evaluating during an auth-token blip while <Authenticated> still renders)
- * keeps the last resolved value, and a `null` with nothing to fall back on
- * renders the defaults rather than hanging on a skeleton forever.
+ * waits for the query to resolve to a real row (both `undefined` while loading
+ * and the transient `null` while the auth token attaches — the backend only
+ * returns `null` for "no identity", never for "no stored row"), so the
+ * calendar never mounts in the browser zone and then flips to the working
+ * zone. After that first resolution the workspace NEVER unmounts on this
+ * query: a later `null` (an auth-token blip while <Authenticated> still
+ * renders) keeps the last resolved value.
  */
 export function PreferencesProvider({ children }: { children: ReactNode }) {
   const raw = useStableQuery(api.domains.preferences.queries.getMyPreferences);
@@ -78,12 +70,8 @@ export function PreferencesProvider({ children }: { children: ReactNode }) {
   if (value) lastValue.current = value;
   const effective = value ?? lastValue.current;
 
-  if (!effective && raw === undefined) return <WorkspaceSkeleton />;
-  return (
-    <PreferencesContext value={effective ?? resolve(EMPTY_RAW)}>
-      {children}
-    </PreferencesContext>
-  );
+  if (!effective) return <WorkspaceSkeleton />;
+  return <PreferencesContext value={effective}>{children}</PreferencesContext>;
 }
 
 export function usePreferences(): PreferencesValue {

--- a/apps/web/src/components/workspace/settings-panel.tsx
+++ b/apps/web/src/components/workspace/settings-panel.tsx
@@ -950,7 +950,7 @@ function PreferencesSection() {
       )}
       <SettingRow
         title="Time zone"
-        description="The zone your booking page's hours are published in"
+        description="Your calendar and booking page run in this zone"
         control={
           <TimeZonePicker
             value={prefs.timeZone}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1,1 +1,14 @@
 @import "@qali/ui/globals.css";
+
+/* The calendar's vertical scroll deliberately chains to the document so the
+ * macOS rubber-band keeps its native springy feel (Chromium only bounces the
+ * root scroller, never inner overflow divs). The bounce reveals the html
+ * canvas beyond the page edge, so pin it to the app background — otherwise
+ * the prepaint hexes in index.html (near-but-not-equal to the tokens) show
+ * through as an off-color band. The class selectors out-rank the inline
+ * prepaint rules; the bare `html` covers any classless moment. */
+html,
+html.light,
+html.dark {
+  background-color: var(--background);
+}

--- a/bun.lock
+++ b/bun.lock
@@ -22,6 +22,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@convex-dev/better-auth": "catalog:",
+        "@date-fns/tz": "^1.5.0",
         "@hookform/resolvers": "^5.4.0",
         "@hugeicons/core-free-icons": "^4.2.2",
         "@hugeicons/react": "^1.1.9",
@@ -296,6 +297,8 @@
     "@convex-dev/better-auth": ["@convex-dev/better-auth@0.12.5", "", { "dependencies": { "@better-fetch/fetch": "^1.1.18", "common-tags": "^1.8.2", "convex-helpers": "^0.1.95", "jose": "^6.1.0", "remeda": "^2.32.0", "semver": "^7.7.3", "type-fest": "^5.0.0", "zod": "^4.0.0" }, "peerDependencies": { "better-auth": ">=1.6.11 <1.7.0", "convex": "^1.25.0", "react": "^18.3.1 || ^19.0.0" } }, "sha512-YFUbGk04OlINno9FpOTNZN67AP+kSQsblfep5zs1f/WTgMWjD5FymU6rSSh3mu52gukmDNnBJTjC/lj4QRpjlQ=="],
 
     "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="],
+
+    "@date-fns/tz": ["@date-fns/tz@1.5.0", "", {}, "sha512-lwYN/vDPeNRULcepoE/LO2Pgx+7/RV+S9ARfbc9lr2DtGkOD7pAiruHvbR1RX3Qyf6ja47EWJDMsNK5vK08DJg=="],
 
     "@dotenvx/dotenvx": ["@dotenvx/dotenvx@1.75.1", "", { "dependencies": { "@dotenvx/primitives": "^0.8.0", "commander": "^11.1.0", "conf": "^10.2.0", "dotenv": "^17.2.1", "enquirer": "^2.4.1", "env-paths": "^2.2.1", "execa": "^5.1.1", "fdir": "^6.2.0", "ignore": "^5.3.0", "object-treeify": "1.1.33", "open": "^8.4.2", "picomatch": "^4.0.4", "systeminformation": "^5.22.11", "undici": "^7.11.0", "which": "^4.0.0", "yocto-spinner": "^1.1.0" }, "bin": { "dotenvx": "src/cli/dotenvx.js" } }, "sha512-/BITOC9dmS/edY2zQwZNicQ059O6RKabtQfyEafV0nGtfYRNHYy1DIPiYVcov40+tob9hfmBnbR963dS+EQ1DQ=="],
 


### PR DESCRIPTION
## What

The timezone preference (added in #14) graduates from a booking-page label to the calendar's **working zone**, applied end to end: the grid cuts days in it, the gutter labels hours in it, wheels compose times in it, event writes are anchored to it, and the assistant resolves "tomorrow" in it. Set your zone to New York from Addis Ababa and the whole calendar *is* a New York calendar.

## How

date-fns v4 + `@date-fns/tz`. A `TZDate`'s zone propagates through every date-fns function, so the change concentrates at the entry points:

- **Anchors** — `lib.ts` gains `zoned(ms, tz)` / `zonedNow(tz)`; the calendar anchor and every now/picker-fed date is a working-zone `TZDate`, and `stripDays`/`pageStart`/`format`/`isToday` stay signature-compatible while becoming zone-correct. The day-intern cache keys on zone so a preference flip can't resurrect old-zone days.
- **Rendering** — gutter hours (`timezoneGutters` replaces the browser-pinned `TIMEZONES`), the now line/badge, day headers, event cards/detail/ghost, booking blocks and request labels all read the working zone. Intl formatters are cached per zone/clock instead of rebuilt per render.
- **Composition** — event-form wheels, all-day UTC boundaries, drag resize day cuts, recurrence weekday/UNTIL/parse/summarize, and repeat-control presets all take the zone.
- **Labels** — event create/edit/drag and assistant sends stamp the working zone, which now truthfully names the zone the wall clock was composed in (the #14 review's invariant, preserved).
- **Availability painting** — date keys come off the zone-cut grid; the edit gate compares the page zone to the working zone and self-heals on save, so the "painting disabled" state from #14 is gone.

The public booking page stays visitor-local by design (verified: no shared date code crosses the boundary).

## Testing

- New `working-zone.test.ts`: same-instant day divergence across the date line, week-cut instant deltas (NY vs UTC+14), zone-aware now-indicator positions, all-day boundary dates, recurrence weekday/UNTIL stamps — all with fixed zones, no ambient-TZ dependence.
- 111 web unit tests pass; `tsc` and the production build are clean; rrule/event-edit tests updated for the new zone parameters.

## Known limitation

Day columns assume 24-hour days, so event positions on a DST-transition day (23/25h) are approximate — exact parity with the pre-existing browser-zone behavior, now noted in the commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)