### PR TITLE
Multi-account support: link additional Google accounts

### DIFF
--- a/apps/web/src/components/calendar/calendar.tsx
+++ b/apps/web/src/components/calendar/calendar.tsx
@@ -9,7 +9,7 @@ import type { Doc } from "@qali/backend/convex/_generated/dataModel";
 import { Checkbox } from "@qali/ui/components/checkbox";
 import { GooDropdown } from "@qali/ui/components/ui/goo-dropdown";
 import { cn } from "@qali/ui/lib/utils";
-import { useMutation } from "convex/react";
+import { useMutation, useQuery } from "convex/react";
 import { addDays, getISOWeek, isSameDay, isSameMonth, startOfDay } from "date-fns";
 import { useReducedMotion } from "motion/react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -24,6 +24,7 @@ import {
   type CalendarView,
   dayKey,
   eventQueryRange,
+  groupCalendarsByAccount,
   msToPct,
   pageDays,
   pageStart,
@@ -430,12 +431,15 @@ export function CalendarWeekView() {
 
 function CalendarPicker({ calendars }: { calendars: CalendarListItem[] }) {
   const setSelected = useMutation(api.domains.calendar.mutations.setCalendarSelected);
+  const connections =
+    useQuery(api.domains.calendar.queries.listConnections) ?? [];
   const selectedCount = calendars.filter((c) => c.selected).length;
   // Primary first, then alphabetical by display name.
   const sorted = [...calendars].sort((a, b) => {
     if (a.primary !== b.primary) return a.primary ? -1 : 1;
     return calendarDisplayName(a).localeCompare(calendarDisplayName(b));
   });
+  const grouped = groupCalendarsByAccount(sorted, connections);
 
   return (
     <GooDropdown
@@ -472,13 +476,20 @@ function CalendarPicker({ calendars }: { calendars: CalendarListItem[] }) {
             Calendars
           </p>
           <div className="min-h-0 flex-1 overflow-y-auto [scrollbar-width:thin]">
-            {sorted.map((cal, index) => (
+            {grouped.map((group) => (
+              <div key={group.key}>
+                {grouped.length > 1 && group.label && (
+                  <p className="flex h-6 items-center truncate px-1.5 pt-1 text-[11px] font-medium opacity-60">
+                    {group.label}
+                  </p>
+                )}
+            {group.calendars.map((cal) => (
               <label
                 key={cal._id}
                 className="flex h-8 cursor-pointer items-center gap-2.5 rounded-lg px-1.5 transition-colors hover:bg-[var(--goo-hover-fill)]"
               >
                 <Checkbox
-                  autoFocus={index === 0}
+                  autoFocus={cal._id === sorted[0]?._id}
                   className="size-5 rounded-md border-primary-foreground/40 bg-primary-foreground/10 transition-colors focus-visible:border-primary-foreground focus-visible:ring-primary-foreground/30 data-checked:border-primary-foreground data-checked:bg-primary-foreground data-checked:text-primary dark:data-checked:bg-primary-foreground"
                   checked={cal.selected}
                   onCheckedChange={(checked) =>
@@ -499,10 +510,16 @@ function CalendarPicker({ calendars }: { calendars: CalendarListItem[] }) {
                 </span>
               </label>
             ))}
+              </div>
+            ))}
           </div>
         </div>
       }
-      contentHeight={28 + Math.min(sorted.length, 8) * 32}
+      contentHeight={
+        28 +
+        Math.min(sorted.length, 8) * 32 +
+        (grouped.length > 1 ? grouped.filter((g) => g.label).length * 28 : 0)
+      }
       triggerSound={false}
       align="end"
       side="bottom"

--- a/apps/web/src/components/calendar/event-controls.tsx
+++ b/apps/web/src/components/calendar/event-controls.tsx
@@ -1,6 +1,8 @@
 import { Calendar03Icon, Tick02Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
+import { api } from "@qali/backend/convex/_generated/api";
 import type { Id } from "@qali/backend/convex/_generated/dataModel";
+import { useQuery } from "convex/react";
 import {
   Popover,
   PopoverContent,
@@ -16,6 +18,7 @@ import { cn } from "@qali/ui/lib/utils";
 import { calendarColorVar, EVENT_COLOR_CHOICES } from "./colors";
 import {
   calendarDisplayName,
+  groupCalendarsByAccount,
   isWritableCalendar,
   type CalendarListItem,
 } from "./lib";
@@ -60,7 +63,11 @@ export function EventControls({
   disabled = false,
   canChangeCalendar = false,
 }: EventControlsProps) {
+  const connections =
+    useQuery(api.domains.calendar.queries.listConnections) ?? [];
   const writable = sortCalendars(calendars.filter(isWritableCalendar));
+  // Two accounts can each have a "Personal"; the account label tells them apart.
+  const grouped = groupCalendarsByAccount(writable, connections);
   // An event can sit on a calendar we can't write to; still name it.
   const selected =
     writable.find((c) => c._id === calendarId) ??
@@ -138,24 +145,33 @@ export function EventControls({
         </Tooltip>
         <PopoverContent side="top" align="start" className="w-64 p-2">
           <div className="flex flex-col gap-0.5">
-            {writable.map((cal) => (
-              <button
-                key={cal._id}
-                type="button"
-                onClick={() => onCalendarChange(cal._id)}
-                className="flex items-center gap-2.5 rounded-lg px-1.5 py-1.5 text-left outline-none hover:bg-accent focus-visible:ring-2 focus-visible:ring-ring"
-              >
-                <span
-                  className="size-3 shrink-0 rounded-full"
-                  style={{ backgroundColor: `var(${calendarColorVar(cal)})` }}
-                />
-                <span className="min-w-0 flex-1 truncate text-sm">
-                  {calendarDisplayName(cal)}
-                </span>
-                {cal._id === calendarId && (
-                  <HugeiconsIcon icon={Tick02Icon} strokeWidth={2.5} className="size-4" />
+            {grouped.map((group) => (
+              <div key={group.key} className="flex flex-col gap-0.5">
+                {grouped.length > 1 && group.label && (
+                  <p className="truncate px-1.5 pt-1 text-[11px] font-medium text-muted-foreground">
+                    {group.label}
+                  </p>
                 )}
-              </button>
+                {group.calendars.map((cal) => (
+                  <button
+                    key={cal._id}
+                    type="button"
+                    onClick={() => onCalendarChange(cal._id)}
+                    className="flex items-center gap-2.5 rounded-lg px-1.5 py-1.5 text-left outline-none hover:bg-accent focus-visible:ring-2 focus-visible:ring-ring"
+                  >
+                    <span
+                      className="size-3 shrink-0 rounded-full"
+                      style={{ backgroundColor: `var(${calendarColorVar(cal)})` }}
+                    />
+                    <span className="min-w-0 flex-1 truncate text-sm">
+                      {calendarDisplayName(cal)}
+                    </span>
+                    {cal._id === calendarId && (
+                      <HugeiconsIcon icon={Tick02Icon} strokeWidth={2.5} className="size-4" />
+                    )}
+                  </button>
+                ))}
+              </div>
             ))}
             {writable.length === 0 && (
               <p className="px-1.5 py-1 text-sm text-muted-foreground">

--- a/apps/web/src/components/calendar/event-create.tsx
+++ b/apps/web/src/components/calendar/event-create.tsx
@@ -54,8 +54,8 @@ export function EventCreate({
 }) {
   const createEvent = useAction(api.domains.calendar.service.createEvent);
   const calendars = useQuery(api.domains.calendar.queries.listCalendars) ?? [];
-  const connections =
-    useQuery(api.domains.calendar.queries.listConnections) ?? [];
+  // Left undefined while loading on purpose — see pickPrimaryCalendar.
+  const connections = useQuery(api.domains.calendar.queries.listConnections);
   const { defaultCalendarId, timeZone } = usePreferences();
   const [submitting, setSubmitting] = useState(false);
   // Idempotency key for this create intent: minted once and reused across retries

--- a/apps/web/src/components/calendar/event-create.tsx
+++ b/apps/web/src/components/calendar/event-create.tsx
@@ -14,7 +14,7 @@ import {
   toEventTimes,
   type EventFormValue,
 } from "./event-form";
-import { isWritableCalendar } from "./lib";
+import { isWritableCalendar, pickPrimaryCalendar } from "./lib";
 import { toRRule } from "./rrule";
 
 /** A new event has no owner to answer to yet, so every control is live. */
@@ -54,6 +54,8 @@ export function EventCreate({
 }) {
   const createEvent = useAction(api.domains.calendar.service.createEvent);
   const calendars = useQuery(api.domains.calendar.queries.listCalendars) ?? [];
+  const connections =
+    useQuery(api.domains.calendar.queries.listConnections) ?? [];
   const { defaultCalendarId, timeZone } = usePreferences();
   const [submitting, setSubmitting] = useState(false);
   // Idempotency key for this create intent: minted once and reused across retries
@@ -90,7 +92,7 @@ export function EventCreate({
       (c) =>
         c._id === defaultCalendarId && !c.isShared && isWritableCalendar(c),
     )?._id ??
-    calendars.find((c) => c.primary)?._id;
+    pickPrimaryCalendar(calendars, connections)?._id;
   const value: EventFormValue = {
     ...draft,
     calendarId: activeCalendarId,

--- a/apps/web/src/components/calendar/lib.test.ts
+++ b/apps/web/src/components/calendar/lib.test.ts
@@ -5,7 +5,11 @@ import { describe, expect, test } from "bun:test";
 import {
   calendarDisplayName,
   type CalendarEvent,
+  type CalendarListItem,
+  type ConnectionListItem,
   formatWallClockMinutes,
+  groupCalendarsByAccount,
+  pickPrimaryCalendar,
   LANE_ADVANCE_RATIO,
   laneBox,
   WEEK_LANE_TILE_MAX_STAGGER_MS,
@@ -549,5 +553,77 @@ describe("eventQueryRange", () => {
       const sameWeek = new Date(monday.getTime() + i * MS_PER_DAY);
       expect(eventQueryRange("week", sameWeek)).toEqual(base);
     }
+  });
+});
+
+describe("multi-account picker helpers", () => {
+  const cal = (id: string, connectionId?: string, primary = false) =>
+    ({
+      _id: id,
+      connectionId,
+      primary,
+      selected: true,
+      isShared: false,
+    }) as unknown as CalendarListItem;
+  const conn = (
+    id: string,
+    createdAt: number,
+    over: Partial<{ status: string; provider: string; providerAccountId: string }> = {},
+  ) =>
+    ({
+      _id: id,
+      provider: "google",
+      status: "active",
+      createdAt,
+      ...over,
+    }) as unknown as ConnectionListItem;
+
+  test("pickPrimaryCalendar returns the lone primary without consulting connections", () => {
+    const primary = cal("p", "c1", true);
+    expect(pickPrimaryCalendar([cal("a", "c1"), primary], [])).toBe(primary);
+    expect(pickPrimaryCalendar([cal("a", "c1")], [])).toBeUndefined();
+  });
+
+  test("pickPrimaryCalendar prefers the oldest active connection's primary", () => {
+    const loginPrimary = cal("login-p", "login", true);
+    const linkedPrimary = cal("linked-p", "linked", true);
+    const connections = [conn("linked", 2), conn("login", 1)];
+    expect(
+      pickPrimaryCalendar([linkedPrimary, loginPrimary], connections),
+    ).toBe(loginPrimary);
+    // A paused login connection cedes the default to the linked account.
+    expect(
+      pickPrimaryCalendar(
+        [linkedPrimary, loginPrimary],
+        [conn("linked", 2), conn("login", 1, { status: "paused" })],
+      ),
+    ).toBe(linkedPrimary);
+  });
+
+  test("groupCalendarsByAccount stays flat for a single account", () => {
+    const calendars = [cal("a", "c1"), cal("b", "c1")];
+    expect(groupCalendarsByAccount(calendars, [conn("c1", 1)])).toEqual([
+      { key: "all", calendars },
+    ]);
+    expect(groupCalendarsByAccount([], [conn("c1", 1)])).toEqual([]);
+  });
+
+  test("groupCalendarsByAccount labels per connection, oldest first, orphans last", () => {
+    const a = cal("a", "login");
+    const b = cal("b", "linked");
+    const orphan = cal("o", undefined);
+    const groups = groupCalendarsByAccount(
+      [b, a, orphan],
+      [
+        conn("linked", 2, { providerAccountId: "second@example.com" }),
+        conn("login", 1, { providerAccountId: "first@example.com" }),
+      ],
+    );
+    expect(groups.map((g) => g.label)).toEqual([
+      "first@example.com",
+      "second@example.com",
+      "Other",
+    ]);
+    expect(groups.map((g) => g.calendars)).toEqual([[a], [b], [orphan]]);
   });
 });

--- a/apps/web/src/components/calendar/lib.ts
+++ b/apps/web/src/components/calendar/lib.ts
@@ -65,6 +65,34 @@ export function isWritableCalendar(calendar: {
   return WRITABLE_ACCESS_ROLES.has(calendar.accessRole ?? "");
 }
 
+/** One row of the `listConnections` DTO, mirroring {@link CalendarListItem}. */
+export type ConnectionListItem = FunctionReturnType<
+  typeof api.domains.calendar.queries.listConnections
+>[number];
+
+/** The default calendar when nothing is chosen: the primary calendar of the
+ * preferred connection. With several connected accounts each contributing a
+ * `primary` calendar, this mirrors the backend's `preferredConnection`
+ * ordering (active → Google first → oldest) so the client's preview and the
+ * server's resolved target can never disagree. */
+export function pickPrimaryCalendar(
+  calendars: CalendarListItem[],
+  connections: ConnectionListItem[],
+): CalendarListItem | undefined {
+  const primaries = calendars.filter((c) => c.primary);
+  if (primaries.length <= 1) return primaries[0];
+  const preferred = connections
+    .filter((c) => c.status === "active")
+    .sort(
+      (a, b) =>
+        Number(b.provider === "google") - Number(a.provider === "google") ||
+        a.createdAt - b.createdAt,
+    )[0];
+  return (
+    primaries.find((c) => c.connectionId === preferred?._id) ?? primaries[0]
+  );
+}
+
 /** User-facing calendar name, including a per-user override when one exists.
  * `providerCalendarId` is optional only for the transitional schema: a
  * pre-cutover row without one renders nameless rather than borrowing a legacy

--- a/apps/web/src/components/calendar/lib.ts
+++ b/apps/web/src/components/calendar/lib.ts
@@ -77,10 +77,15 @@ export type ConnectionListItem = FunctionReturnType<
  * server's resolved target can never disagree. */
 export function pickPrimaryCalendar(
   calendars: CalendarListItem[],
-  connections: ConnectionListItem[],
+  connections: ConnectionListItem[] | undefined,
 ): CalendarListItem | undefined {
   const primaries = calendars.filter((c) => c.primary);
   if (primaries.length <= 1) return primaries[0];
+  // Which account wins is unknowable until the connections load. Returning
+  // nothing leaves `calendarId` unset, so the server resolves the target
+  // through `preferredConnection` instead of honouring a guess sent as an
+  // explicit request.
+  if (connections === undefined) return undefined;
   const preferred = connections
     .filter((c) => c.status === "active")
     .sort(

--- a/apps/web/src/components/calendar/lib.ts
+++ b/apps/web/src/components/calendar/lib.ts
@@ -93,6 +93,33 @@ export function pickPrimaryCalendar(
   );
 }
 
+/** Calendars grouped for pickers: one unlabeled group while there's a single
+ * account, one group per connection (oldest first, matching the preferred-
+ * connection ordering) once a second is linked. Input order is preserved
+ * inside each group, so callers sort first and group after. */
+export function groupCalendarsByAccount(
+  calendars: CalendarListItem[],
+  connections: ConnectionListItem[],
+): { key: string; label?: string; calendars: CalendarListItem[] }[] {
+  if (connections.length <= 1) {
+    return calendars.length > 0 ? [{ key: "all", calendars }] : [];
+  }
+  const ordered = [...connections].sort((a, b) => a.createdAt - b.createdAt);
+  const known = new Set<string>(ordered.map((c) => c._id));
+  const groups = ordered.map((connection) => ({
+    key: connection._id as string,
+    label: connection.providerAccountId ?? "Connected account",
+    calendars: calendars.filter((c) => c.connectionId === connection._id),
+  }));
+  const orphans = calendars.filter(
+    (c) => c.connectionId === undefined || !known.has(c.connectionId),
+  );
+  if (orphans.length > 0) {
+    groups.push({ key: "other", label: "Other", calendars: orphans });
+  }
+  return groups.filter((group) => group.calendars.length > 0);
+}
+
 /** User-facing calendar name, including a per-user override when one exists.
  * `providerCalendarId` is optional only for the transitional schema: a
  * pre-cutover row without one renders nameless rather than borrowing a legacy

--- a/apps/web/src/components/workspace/settings-panel.tsx
+++ b/apps/web/src/components/workspace/settings-panel.tsx
@@ -536,9 +536,12 @@ function ConnectionCard({
   const errored = connection.status === "error";
   const providerName =
     connection.provider === "google" ? "Google Calendar" : "Outlook";
-  // The session's identity stands in only for the login grant (primary);
-  // any other connection shows its own account id or an honest placeholder.
-  const accountName = primary ? (session?.user?.name ?? providerName) : providerName;
+  // The session's identity stands in only for the login grant (primary); any
+  // other connection shows its own stamped profile, falling back to the bare
+  // provider while the profile is still pending.
+  const accountName = primary
+    ? (session?.user?.name ?? providerName)
+    : (connection.providerAccountName ?? providerName);
   const accountLabel =
     connection.providerAccountId ??
     (primary ? (session?.user?.email ?? "") : "Account details pending sync");
@@ -571,9 +574,21 @@ function ConnectionCard({
     <div className="overflow-hidden rounded-3xl bg-muted/50">
       {/* Identity band: who this account is, tinted apart from its toggles. */}
       <div className="flex items-center gap-3 border-b border-border bg-muted/60 px-4 py-3">
-        {primary ? (
+        {primary || connection.providerAccountImageUrl ? (
           <span className="relative shrink-0">
-            <UserAvatar className="size-9" />
+            {primary ? (
+              <UserAvatar className="size-9" />
+            ) : (
+              <img
+                src={connection.providerAccountImageUrl}
+                alt=""
+                aria-hidden
+                draggable={false}
+                // Google's avatar host rejects requests carrying a referrer.
+                referrerPolicy="no-referrer"
+                className="size-9 rounded-full object-cover"
+              />
+            )}
             <span className="absolute -right-0.5 -bottom-0.5 flex size-4 items-center justify-center rounded-full bg-background shadow-sm">
               <ProviderLogo aria-hidden className="size-2.5" />
             </span>

--- a/apps/web/src/components/workspace/settings-panel.tsx
+++ b/apps/web/src/components/workspace/settings-panel.tsx
@@ -43,6 +43,7 @@ import { toast } from "sonner";
 
 import {
   calendarDisplayName,
+  groupCalendarsByAccount,
   isWritableCalendar,
   type CalendarListItem,
 } from "@/components/calendar/lib";
@@ -515,14 +516,16 @@ function ConnectionCard({
   const { data: session } = authClient.useSession();
   // The login grant gets the session's identity (avatar, name, Primary badge);
   // any other account must show its own providerAccountId — never the
-  // session's name over foreign toggles. A sole connection is the login grant
-  // by construction; with several, the stamped account email proves which one
-  // is (until a sync stamps it, a linked account renders as its provider).
+  // session's name over foreign toggles. The stamped account email is what
+  // proves which one is the login grant; a sole connection only stands in for
+  // it while unstamped, since disconnecting the login account can leave a
+  // single connection that is somebody else entirely.
+  const sessionEmail = session?.user?.email?.toLowerCase();
   const primary =
-    sole ||
     (connection.providerAccountId !== undefined &&
-      connection.providerAccountId.toLowerCase() ===
-        session?.user?.email?.toLowerCase());
+      sessionEmail !== undefined &&
+      connection.providerAccountId.toLowerCase() === sessionEmail) ||
+    (sole && connection.providerAccountId === undefined);
   const setStatus = useMutation(
     api.domains.calendar.mutations.setConnectionStatus,
   );
@@ -758,10 +761,13 @@ function DisconnectButton({
         setBusy(true);
         disconnect({ connectionId })
           .then(() => toast.success("Account disconnected"))
-          .catch((error: unknown) => {
+          .catch(reportSaveError("Couldn't disconnect the account"))
+          // The row outlives the call — it's paused here and deleted by the
+          // background purge — so releasing the button is what keeps a stalled
+          // purge from stranding the card with no way to retry.
+          .finally(() => {
             setBusy(false);
             setArmed(false);
-            reportSaveError("Couldn't disconnect the account")(error);
           });
       }}
     >
@@ -975,6 +981,7 @@ const DEFAULT_VIEW_OPTIONS = [
 function PreferencesSection() {
   const prefs = useQuery(api.domains.preferences.queries.getMyPreferences);
   const calendars = useQuery(api.domains.calendar.queries.listCalendars);
+  const connections = useQuery(api.domains.calendar.queries.listConnections);
   const updatePrefs = useMutation(
     api.domains.preferences.mutations.updatePreferences,
   );
@@ -990,6 +997,10 @@ function PreferencesSection() {
   const writable = sortCalendars(calendars).filter(isWritable);
   const defaultCalendar =
     writable.find((c) => c._id === prefs.defaultCalendarId) ?? null;
+  // Two accounts can each have a "Personal"; without the account heading the
+  // rows are indistinguishable and picking the wrong one silently routes new
+  // events to the other account.
+  const grouped = groupCalendarsByAccount(writable, connections ?? []);
 
   const save = (patch: Parameters<typeof updatePrefs>[0]) =>
     void updatePrefs(patch).catch(
@@ -1064,17 +1075,26 @@ function PreferencesSection() {
                       save({ reset: ["defaultCalendarId"] });
                     }}
                   />
-                  {writable.map((calendar) => (
-                    <PickerOption
-                      key={calendar._id}
-                      label={calendarDisplayName(calendar)}
-                      swatchVar={calendarColorVar(calendar)}
-                      selected={calendar._id === defaultCalendar?._id}
-                      onSelect={() => {
-                        close();
-                        save({ defaultCalendarId: calendar._id });
-                      }}
-                    />
+                  {grouped.map((group) => (
+                    <div key={group.key} className="flex flex-col gap-0.5">
+                      {grouped.length > 1 && group.label && (
+                        <p className="truncate px-2.5 pt-1 text-[11px] font-medium text-muted-foreground">
+                          {group.label}
+                        </p>
+                      )}
+                      {group.calendars.map((calendar) => (
+                        <PickerOption
+                          key={calendar._id}
+                          label={calendarDisplayName(calendar)}
+                          swatchVar={calendarColorVar(calendar)}
+                          selected={calendar._id === defaultCalendar?._id}
+                          onSelect={() => {
+                            close();
+                            save({ defaultCalendarId: calendar._id });
+                          }}
+                        />
+                      ))}
+                    </div>
                   ))}
                 </div>
               )}

--- a/apps/web/src/components/workspace/settings-panel.tsx
+++ b/apps/web/src/components/workspace/settings-panel.tsx
@@ -54,6 +54,7 @@ import {
 } from "@/components/calendar/motion";
 import { useStableQuery } from "@/components/calendar/use-stable-query";
 import { authClient } from "@/lib/auth-client";
+import { useScrollFadeFallback } from "@/lib/use-scroll-fade";
 import { UserAvatar } from "./user-avatar";
 import { useSyncNow } from "./use-sync-now";
 
@@ -147,6 +148,8 @@ export function SettingsPanel({
   }, []);
 
   const variants = reduce ? dockVariantsReduced : dockVariants;
+  // Firefox has no scroll-driven animations; this drives the fade by hand there.
+  const scrollFadeRef = useScrollFadeFallback();
 
   const goTo = (next: SettingsSection) => {
     const from = SECTIONS.findIndex((s) => s.id === section);
@@ -256,7 +259,10 @@ export function SettingsPanel({
                   <h2 className="font-display shrink-0 pr-9 text-2xl font-bold">
                     {active.label}
                   </h2>
-                  <div className="scroll-fade-y -mr-2 mt-4 min-h-0 flex-1 overflow-y-auto pr-2 pb-1 [scrollbar-width:thin]">
+                  <div
+                    ref={scrollFadeRef}
+                    className="scroll-fade-y -mr-2 mt-4 min-h-0 flex-1 overflow-y-auto pr-2 pb-1 [scrollbar-width:thin]"
+                  >
                     {sectionContent}
                   </div>
                 </motion.div>

--- a/apps/web/src/components/workspace/settings-panel.tsx
+++ b/apps/web/src/components/workspace/settings-panel.tsx
@@ -455,10 +455,7 @@ function AccountsSection() {
         <ConnectionCard
           key={connection._id}
           connection={connection}
-          // Only a sole connection is provably the login grant, whose
-          // identity is the session's. A second account must show its own
-          // providerAccountId — never the session's name over foreign toggles.
-          primary={connections.length === 1}
+          sole={connections.length === 1}
           // Disconnecting the only account would strand the login; the sole
           // connection offers Pause instead.
           canDisconnect={connections.length > 1}
@@ -508,14 +505,24 @@ function AddAccountButton() {
 
 function ConnectionCard({
   connection,
-  primary,
+  sole,
   canDisconnect,
 }: {
   connection: Connection;
-  primary: boolean;
+  sole: boolean;
   canDisconnect: boolean;
 }) {
   const { data: session } = authClient.useSession();
+  // The login grant gets the session's identity (avatar, name, Primary badge);
+  // any other account must show its own providerAccountId — never the
+  // session's name over foreign toggles. A sole connection is the login grant
+  // by construction; with several, the stamped account email proves which one
+  // is (until a sync stamps it, a linked account renders as its provider).
+  const primary =
+    sole ||
+    (connection.providerAccountId !== undefined &&
+      connection.providerAccountId.toLowerCase() ===
+        session?.user?.email?.toLowerCase());
   const setStatus = useMutation(
     api.domains.calendar.mutations.setConnectionStatus,
   );

--- a/apps/web/src/components/workspace/settings-panel.tsx
+++ b/apps/web/src/components/workspace/settings-panel.tsx
@@ -27,7 +27,7 @@ import { Spinner } from "@qali/ui/components/spinner";
 import { Switch } from "@qali/ui/components/switch";
 import { cn } from "@qali/ui/lib/utils";
 import type { FunctionReturnType } from "convex/server";
-import { useMutation, useQuery } from "convex/react";
+import { useAction, useMutation, useQuery } from "convex/react";
 import { formatDistanceToNow } from "date-fns";
 import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 import {
@@ -453,6 +453,9 @@ function AccountsSection() {
           // identity is the session's. A second account must show its own
           // providerAccountId — never the session's name over foreign toggles.
           primary={connections.length === 1}
+          // Disconnecting the only account would strand the login; the sole
+          // connection offers Pause instead.
+          canDisconnect={connections.length > 1}
         />
       ))}
       <AddAccountButton />
@@ -500,9 +503,11 @@ function AddAccountButton() {
 function ConnectionCard({
   connection,
   primary,
+  canDisconnect,
 }: {
   connection: Connection;
   primary: boolean;
+  canDisconnect: boolean;
 }) {
   const { data: session } = authClient.useSession();
   const setStatus = useMutation(
@@ -673,8 +678,68 @@ function ConnectionCard({
             )
           }
         />
+        {canDisconnect && (
+          <SettingRow
+            title="Disconnect"
+            description="Removes this account and everything it synced"
+            control={<DisconnectButton connectionId={connection._id} />}
+          />
+        )}
       </div>
     </div>
+  );
+}
+
+const DISCONNECT_CONFIRM_TIMEOUT_MS = 4_000;
+
+/** Two-step disconnect, same shape as the event panel's delete: the dock has
+ * no modal layer, so the button confirms on itself and disarms if the second
+ * click never comes. */
+function DisconnectButton({
+  connectionId,
+}: {
+  connectionId: Id<"calendarConnections">;
+}) {
+  const disconnect = useAction(
+    api.domains.calendar.connectionService.disconnectAccount,
+  );
+  const [armed, setArmed] = useState(false);
+  const [busy, setBusy] = useState(false);
+
+  useEffect(() => {
+    if (!armed) return;
+    const timer = setTimeout(
+      () => setArmed(false),
+      DISCONNECT_CONFIRM_TIMEOUT_MS,
+    );
+    return () => clearTimeout(timer);
+  }, [armed]);
+
+  return (
+    <Button
+      type="button"
+      size="sm"
+      variant={armed ? "destructive" : "secondary"}
+      disabled={busy}
+      aria-busy={busy}
+      onClick={() => {
+        if (!armed) {
+          setArmed(true);
+          return;
+        }
+        setBusy(true);
+        disconnect({ connectionId })
+          .then(() => toast.success("Account disconnected"))
+          .catch((error: unknown) => {
+            setBusy(false);
+            setArmed(false);
+            reportSaveError("Couldn't disconnect the account")(error);
+          });
+      }}
+    >
+      {busy && <Spinner />}
+      {busy ? "Disconnecting…" : armed ? "Confirm?" : "Disconnect"}
+    </Button>
   );
 }
 

--- a/apps/web/src/components/workspace/settings-panel.tsx
+++ b/apps/web/src/components/workspace/settings-panel.tsx
@@ -434,9 +434,12 @@ function AccountsSection() {
   if (connections.length === 0) {
     return (
       <SettingCard>
-        <p className="py-8 text-center text-xs text-muted-foreground">
-          No connected accounts yet — they appear after your first sync.
-        </p>
+        <div className="flex flex-col items-center gap-4 py-8">
+          <p className="text-center text-xs text-muted-foreground">
+            No connected accounts yet — they appear after your first sync.
+          </p>
+          <AddAccountButton />
+        </div>
       </SettingCard>
     );
   }
@@ -452,7 +455,45 @@ function AccountsSection() {
           primary={connections.length === 1}
         />
       ))}
+      <AddAccountButton />
     </div>
+  );
+}
+
+/** Starts Better Auth's link flow: the Google chooser + consent, then back to
+ * the workspace with `?linked=google`, where connectLinkedAccounts turns the
+ * new grant into a connection. */
+function AddAccountButton() {
+  const [isLinking, setIsLinking] = useState(false);
+
+  const linkAccount = async () => {
+    setIsLinking(true);
+    await authClient.linkSocial(
+      {
+        provider: "google",
+        callbackURL: "/?linked=google",
+        errorCallbackURL: "/?linkError=google",
+      },
+      {
+        onError: (error) => {
+          setIsLinking(false);
+          toast.error(error.error.message || error.error.statusText);
+        },
+      },
+    );
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={() => void linkAccount()}
+      disabled={isLinking}
+      aria-busy={isLinking}
+      className="flex w-full items-center justify-center gap-2 rounded-3xl border border-dashed border-border bg-muted/30 px-4 py-4 text-sm font-medium text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-60"
+    >
+      {isLinking ? <Spinner /> : <Google aria-hidden className="size-4" />}
+      {isLinking ? "Opening Google…" : "Add Google account"}
+    </button>
   );
 }
 

--- a/apps/web/src/lib/use-scroll-fade.ts
+++ b/apps/web/src/lib/use-scroll-fade.ts
@@ -1,0 +1,77 @@
+import { useCallback, type RefCallback } from "react";
+
+/** The shadcn `scroll-fade-*` utilities drive their mask with scroll-driven
+ * animations. Where those are missing (Firefox), the utility's own fallback
+ * paints BOTH fades statically, so content at the very top of the scroller
+ * sits under a fade that never lifts. */
+const hasScrollTimeline =
+  typeof CSS !== "undefined" && CSS.supports("animation-timeline", "scroll()");
+
+/** How far the native version scrolls before a fade is fully revealed:
+ * `--scroll-fade-reveal`, default `calc(var(--spacing) * 24)` = 6rem. */
+const REVEAL_PX = 96;
+
+/**
+ * Fallback driver for a `scroll-fade-y` scroller. Attach the returned ref to
+ * the scrolling element. In browsers with scroll-driven animations this does
+ * nothing (the CSS animation outranks inline styles anyway); elsewhere it
+ * mirrors the scroll position into `--scroll-fade-t`/`--scroll-fade-b`, which
+ * as inline styles override the utility's static `@supports not` fallback.
+ *
+ * Returns a React 19 ref with a per-node cleanup function — with
+ * AnimatePresence an exiting node unmounts AFTER its replacement mounts, so a
+ * shared "last cleanup" slot would tear down the new node's wiring.
+ */
+export function useScrollFadeFallback(): RefCallback<HTMLElement> {
+  return useCallback((node: HTMLElement | null) => {
+    if (!node || hasScrollTimeline) return;
+
+    let frame = 0;
+    const update = () => {
+      frame = 0;
+      // scrollTop can exceed maxScroll by a fraction of a pixel, so clamp both
+      // ends — a negative factor would push a gradient stop past its edge.
+      const clamp = (n: number) => Math.min(1, Math.max(0, n));
+      const maxScroll = node.scrollHeight - node.clientHeight;
+      const top = maxScroll > 0 ? clamp(node.scrollTop / REVEAL_PX) : 0;
+      const bottom =
+        maxScroll > 0 ? clamp((maxScroll - node.scrollTop) / REVEAL_PX) : 0;
+      // `--_scroll-fade-size-*` is set on the element by the utility itself;
+      // the literal fallback matches its default of min(12%, spacing*10).
+      node.style.setProperty(
+        "--scroll-fade-t",
+        `calc(var(--_scroll-fade-size-t, min(12%, 2.5rem)) * ${top})`,
+      );
+      node.style.setProperty(
+        "--scroll-fade-b",
+        `calc(var(--_scroll-fade-size-b, min(12%, 2.5rem)) * ${bottom})`,
+      );
+    };
+    const schedule = () => {
+      if (!frame) frame = requestAnimationFrame(update);
+    };
+
+    update();
+    node.addEventListener("scroll", schedule, { passive: true });
+    // The pane is fixed-height, so content growth (a section's query landing)
+    // shows up as DOM churn rather than a resize of the node itself — watch
+    // both so the bottom fade appears the moment content overflows.
+    const resize = new ResizeObserver(schedule);
+    resize.observe(node);
+    const mutations = new MutationObserver(schedule);
+    mutations.observe(node, {
+      childList: true,
+      subtree: true,
+      characterData: true,
+    });
+
+    return () => {
+      if (frame) cancelAnimationFrame(frame);
+      node.removeEventListener("scroll", schedule);
+      resize.disconnect();
+      mutations.disconnect();
+      node.style.removeProperty("--scroll-fade-t");
+      node.style.removeProperty("--scroll-fade-b");
+    };
+  }, []);
+}

--- a/apps/web/src/routes/_workspace/index.tsx
+++ b/apps/web/src/routes/_workspace/index.tsx
@@ -2,15 +2,45 @@ import { api } from "@qali/backend/convex/_generated/api";
 import { createFileRoute } from "@tanstack/react-router";
 import { useAction } from "convex/react";
 import { useEffect, useRef } from "react";
+import { toast } from "sonner";
 
 import { CalendarWeekView } from "@/components/calendar/calendar";
+import { useDock } from "@/components/workspace/dock-context";
+
+type LinkReturnSearch = {
+  linked?: string;
+  linkError?: string;
+  error?: string;
+};
 
 export const Route = createFileRoute("/_workspace/")({
+  // The Better Auth link flow returns here with `?linked=google`, or with
+  // `?linkError=google&error=<code>` when the callback rejected the link.
+  validateSearch: (search: Record<string, unknown>): LinkReturnSearch => {
+    const out: LinkReturnSearch = {};
+    if (typeof search.linked === "string") out.linked = search.linked;
+    if (typeof search.linkError === "string") out.linkError = search.linkError;
+    if (typeof search.error === "string") out.error = search.error;
+    return out;
+  },
   component: HomeComponent,
 });
 
+function linkErrorMessage(code: string | undefined): string {
+  if (code === "account_already_linked_to_different_user") {
+    return "That Google account is already connected to a different user.";
+  }
+  return "Couldn't connect the account. Please try again.";
+}
+
 function HomeComponent() {
   const syncNow = useAction(api.domains.sync.engine.syncNow);
+  const connectLinkedAccounts = useAction(
+    api.domains.calendar.connectionService.connectLinkedAccounts,
+  );
+  const { linked, linkError, error } = Route.useSearch();
+  const navigate = Route.useNavigate();
+  const { open } = useDock();
 
   // Register the user for background sync and pull an initial snapshot of their
   // Google calendar + contacts on first load.
@@ -20,6 +50,29 @@ function HomeComponent() {
     didSeed.current = true;
     void syncNow();
   }, [syncNow]);
+
+  // Landing back from a linkSocial redirect: materialize the new grant as a
+  // connection, show the accounts panel, and clean the URL.
+  const didHandleLink = useRef(false);
+  useEffect(() => {
+    if (didHandleLink.current || (!linked && !linkError)) return;
+    didHandleLink.current = true;
+    if (linked) {
+      open({ kind: "settings", section: "accounts" });
+      void connectLinkedAccounts()
+        .then(({ created }) => {
+          if (created > 0) {
+            toast.success("Account connected — syncing its calendars…");
+          }
+        })
+        .catch(() => {
+          toast.error("Couldn't finish connecting the account.");
+        });
+    } else {
+      toast.error(linkErrorMessage(error));
+    }
+    void navigate({ search: {}, replace: true });
+  }, [linked, linkError, error, open, connectLinkedAccounts, navigate]);
 
   return <CalendarWeekView />;
 }

--- a/packages/backend/convex/_generated/api.d.ts
+++ b/packages/backend/convex/_generated/api.d.ts
@@ -23,6 +23,7 @@ import type * as domains_booking_mutations from "../domains/booking/mutations.js
 import type * as domains_booking_queries from "../domains/booking/queries.js";
 import type * as domains_booking_service from "../domains/booking/service.js";
 import type * as domains_booking_tables from "../domains/booking/tables.js";
+import type * as domains_calendar_connectionService from "../domains/calendar/connectionService.js";
 import type * as domains_calendar_connectionTables from "../domains/calendar/connectionTables.js";
 import type * as domains_calendar_connections from "../domains/calendar/connections.js";
 import type * as domains_calendar_model from "../domains/calendar/model.js";
@@ -89,6 +90,7 @@ declare const fullApi: ApiFromModules<{
   "domains/booking/queries": typeof domains_booking_queries;
   "domains/booking/service": typeof domains_booking_service;
   "domains/booking/tables": typeof domains_booking_tables;
+  "domains/calendar/connectionService": typeof domains_calendar_connectionService;
   "domains/calendar/connectionTables": typeof domains_calendar_connectionTables;
   "domains/calendar/connections": typeof domains_calendar_connections;
   "domains/calendar/model": typeof domains_calendar_model;

--- a/packages/backend/convex/auth.ts
+++ b/packages/backend/convex/auth.ts
@@ -17,6 +17,20 @@ function createAuth(ctx: GenericCtx<DataModel>) {
     baseURL: env.CONVEX_SITE_URL,
     trustedOrigins: [siteUrl],
     database: authComponent.adapter(ctx),
+    // Login is OAuth-only, so there is no cheap way to re-prove freshness;
+    // without this, unlink-account (used by disconnect) rejects any session
+    // older than Better Auth's default freshness window.
+    session: { freshAge: 0 },
+    account: {
+      accountLinking: {
+        enabled: true,
+        // A second Google account is by definition a different email; the
+        // linked grant still lands on the signed-in user, never a lookup by
+        // email, so this doesn't open account-takeover-by-email.
+        allowDifferentEmails: true,
+        trustedProviders: ["google"],
+      },
+    },
     socialProviders: {
       google: {
         clientId: env.GOOGLE_CLIENT_ID,

--- a/packages/backend/convex/domains/booking/mutations.ts
+++ b/packages/backend/convex/domains/booking/mutations.ts
@@ -22,6 +22,7 @@ import { consumeRateLimit } from "../../infrastructure/rateLimit";
 import {
   ensureDefaultPrimaryCalendar,
   ensureGoogleConnection,
+  preferredConnection,
 } from "../calendar/connections";
 import { calendarRequestFingerprint } from "../calendar/operationIdentity";
 import { clearBookingNotifications } from "../notifications/model";
@@ -107,7 +108,16 @@ async function primaryGoogleBookingTarget(
   ctx: MutationCtx,
   userId: string,
 ): Promise<BookingTarget> {
-  const connectionId = await ensureGoogleConnection(ctx, userId);
+  const connections = await ctx.db
+    .query("calendarConnections")
+    .withIndex("by_user", (q) => q.eq("userId", userId))
+    .take(101);
+  if (connections.length > 100) {
+    throw new Error("Too many connections to choose a booking target safely");
+  }
+  const connectionId =
+    preferredConnection(connections)?._id ??
+    (await ensureGoogleConnection(ctx, userId));
   const calendar =
     (await primaryLocalCalendar(ctx, userId, connectionId)) ??
     (await ensureDefaultPrimaryCalendar(ctx, userId, connectionId));

--- a/packages/backend/convex/domains/booking/service.ts
+++ b/packages/backend/convex/domains/booking/service.ts
@@ -177,7 +177,7 @@ export async function acceptBookingForHost(
   }
   let adapter;
   try {
-    adapter = await getCalendarAdapter(ctx, claimed.connectionId);
+    adapter = await getCalendarAdapter(ctx, args.hostUserId, claimed.connectionId);
   } catch (error) {
     await ctx.runMutation(
       internal.domains.booking.mutations.releaseBookingAcceptance,
@@ -263,7 +263,7 @@ export async function reconcileBookingAcceptanceHandler(
   if (!claimed) return null;
   let adapter: CalendarProviderAdapter;
   try {
-    adapter = await getCalendarAdapter(ctx, claimed.connectionId);
+    adapter = await getCalendarAdapter(ctx, claimed.hostUserId, claimed.connectionId);
   } catch (error) {
     await ctx.runMutation(
       internal.domains.booking.mutations.releaseBookingAcceptance,

--- a/packages/backend/convex/domains/calendar/connectionService.ts
+++ b/packages/backend/convex/domains/calendar/connectionService.ts
@@ -5,15 +5,20 @@
 import { v } from "convex/values";
 
 import { internal } from "../../_generated/api";
-import type { Doc } from "../../_generated/dataModel";
+import type { Doc, Id } from "../../_generated/dataModel";
 import { action, type ActionCtx } from "../../_generated/server";
 import { authComponent, createAuth } from "../../auth";
+import {
+  fetchGoogleUserProfile,
+  getGoogleAccessToken,
+} from "../../integrations/google/credentials";
 
 /** Diff Better Auth's Google grants against the user's connection rows and
- * create what's missing. The account email is deliberately not fetched here:
- * the first sync stamps it from the primary calendar id (reconcileCalendars),
- * and any provider call that could fetch it sooner shares the same failure
- * domain as that sync anyway. */
+ * create what's missing, then stamp each unstamped connection's profile
+ * (email, name, photo) from the grant's stored ID token. The profile is
+ * cosmetic and best-effort: a failed fetch is only logged, and the first
+ * sync still stamps the email from the primary calendar id
+ * (reconcileCalendars) regardless. */
 export async function reconcileLinkedAccountsForUser(
   ctx: ActionCtx,
   userId: string,
@@ -27,10 +32,45 @@ export async function reconcileLinkedAccountsForUser(
       createdAt: new Date(account.createdAt).getTime(),
     }));
   if (accounts.length === 0) return 0;
-  const result: { created: number } = await ctx.runMutation(
+  const result: {
+    created: number;
+    pendingIdentity: {
+      connectionId: Id<"calendarConnections">;
+      credentialRef: string;
+    }[];
+  } = await ctx.runMutation(
     internal.domains.calendar.mutations.reconcileLinkedAccounts,
     { userId, accounts },
   );
+  for (const pending of result.pendingIdentity) {
+    try {
+      // The broker resolves (and refreshes) this grant's token; the userinfo
+      // endpoint then works for every grant, unlike decoding a stored ID
+      // token, which a refresh cycle may not have kept.
+      const accessToken = await getGoogleAccessToken(
+        ctx,
+        userId,
+        pending.credentialRef,
+      );
+      const profile = await fetchGoogleUserProfile(accessToken);
+      if (!profile) continue;
+      await ctx.runMutation(
+        internal.domains.calendar.mutations.stampConnectionIdentity,
+        {
+          userId,
+          connectionId: pending.connectionId,
+          providerAccountId: profile.email,
+          providerAccountName: profile.name,
+          providerAccountImageUrl: profile.picture,
+        },
+      );
+    } catch (error) {
+      console.warn(
+        "Linked-account profile fetch failed:",
+        error instanceof Error ? error.message : error,
+      );
+    }
+  }
   return result.created;
 }
 

--- a/packages/backend/convex/domains/calendar/connectionService.ts
+++ b/packages/backend/convex/domains/calendar/connectionService.ts
@@ -1,0 +1,53 @@
+/** The linking side of the connection model: turning the Google grants Better
+ * Auth holds for a user into `calendarConnections` rows. Registration is
+ * canonical here, under `api.domains.calendar.connectionService.*`. */
+
+import { v } from "convex/values";
+
+import { internal } from "../../_generated/api";
+import { action, type ActionCtx } from "../../_generated/server";
+import { authComponent, createAuth } from "../../auth";
+
+/** Diff Better Auth's Google grants against the user's connection rows and
+ * create what's missing. The account email is deliberately not fetched here:
+ * the first sync stamps it from the primary calendar id (reconcileCalendars),
+ * and any provider call that could fetch it sooner shares the same failure
+ * domain as that sync anyway. */
+export async function reconcileLinkedAccountsForUser(
+  ctx: ActionCtx,
+  userId: string,
+): Promise<number> {
+  const auth = createAuth(ctx);
+  const headers = await authComponent.getHeaders(ctx);
+  const accounts = (await auth.api.listUserAccounts({ headers }))
+    .filter((account) => account.providerId === "google")
+    .map((account) => ({
+      credentialRef: account.accountId,
+      createdAt: new Date(account.createdAt).getTime(),
+    }));
+  if (accounts.length === 0) return 0;
+  const result: { created: number } = await ctx.runMutation(
+    internal.domains.calendar.mutations.reconcileLinkedAccounts,
+    { userId, accounts },
+  );
+  return result.created;
+}
+
+/** Called when the app returns from a `linkSocial` redirect. The link callback
+ * only writes Better Auth's account row, so this is what materializes the
+ * connection and starts its first sync. */
+export const connectLinkedAccounts = action({
+  args: {},
+  returns: v.object({ created: v.number() }),
+  handler: async (ctx) => {
+    const user = await authComponent.safeGetAuthUser(ctx);
+    if (!user) throw new Error("Not authenticated");
+    const created = await reconcileLinkedAccountsForUser(ctx, user._id);
+    if (created > 0) {
+      await ctx.scheduler.runAfter(0, internal.domains.sync.engine.syncUser, {
+        userId: user._id,
+      });
+    }
+    return { created };
+  },
+});

--- a/packages/backend/convex/domains/calendar/connectionService.ts
+++ b/packages/backend/convex/domains/calendar/connectionService.ts
@@ -43,6 +43,7 @@ export async function reconcileLinkedAccountsForUser(
     { userId, accounts },
   );
   for (const pending of result.pendingIdentity) {
+    let profile: Awaited<ReturnType<typeof fetchGoogleUserProfile>> = null;
     try {
       // The broker resolves (and refreshes) this grant's token; the userinfo
       // endpoint then works for every grant, unlike decoding a stored ID
@@ -52,24 +53,26 @@ export async function reconcileLinkedAccountsForUser(
         userId,
         pending.credentialRef,
       );
-      const profile = await fetchGoogleUserProfile(accessToken);
-      if (!profile) continue;
-      await ctx.runMutation(
-        internal.domains.calendar.mutations.stampConnectionIdentity,
-        {
-          userId,
-          connectionId: pending.connectionId,
-          providerAccountId: profile.email,
-          providerAccountName: profile.name,
-          providerAccountImageUrl: profile.picture,
-        },
-      );
+      profile = await fetchGoogleUserProfile(accessToken);
     } catch (error) {
       console.warn(
         "Linked-account profile fetch failed:",
         error instanceof Error ? error.message : error,
       );
     }
+    // Stamped even when the profile is missing: the mutation records the
+    // attempt, which is what stops a revoked or nameless grant from being
+    // refetched on every sync.
+    await ctx.runMutation(
+      internal.domains.calendar.mutations.stampConnectionIdentity,
+      {
+        userId,
+        connectionId: pending.connectionId,
+        providerAccountId: profile?.email,
+        providerAccountName: profile?.name,
+        providerAccountImageUrl: profile?.picture,
+      },
+    );
   }
   return result.created;
 }

--- a/packages/backend/convex/domains/calendar/connectionService.ts
+++ b/packages/backend/convex/domains/calendar/connectionService.ts
@@ -5,6 +5,7 @@
 import { v } from "convex/values";
 
 import { internal } from "../../_generated/api";
+import type { Doc } from "../../_generated/dataModel";
 import { action, type ActionCtx } from "../../_generated/server";
 import { authComponent, createAuth } from "../../auth";
 
@@ -49,5 +50,67 @@ export const connectLinkedAccounts = action({
       });
     }
     return { created };
+  },
+});
+
+/** Remove a linked account: revoke the Better Auth grant (so the reconcile
+ * safety net can't resurrect the connection), take it out of the sync
+ * fan-out, and purge everything it synced in the background. The sole
+ * remaining account can only be paused, never disconnected — that would
+ * strand the user's login. */
+export const disconnectAccount = action({
+  args: { connectionId: v.id("calendarConnections") },
+  returns: v.null(),
+  handler: async (ctx, args): Promise<null> => {
+    const user = await authComponent.safeGetAuthUser(ctx);
+    if (!user) throw new Error("Not authenticated");
+    const target: {
+      connection: Doc<"calendarConnections">;
+      providerConnectionCount: number;
+    } | null = await ctx.runQuery(
+      internal.domains.calendar.queries.getConnectionForRemoval,
+      { connectionId: args.connectionId, userId: user._id },
+    );
+    if (!target) throw new Error("Connection not found");
+    const { connection, providerConnectionCount } = target;
+    if (providerConnectionCount < 2) {
+      throw new Error(
+        "Your only account can't be disconnected — pause it instead",
+      );
+    }
+    if (!connection.credentialRef) {
+      // Without a credentialRef there is no grant to target; the next sync's
+      // reconcile stamps it, so this is transient.
+      throw new Error(
+        "This account hasn't finished connecting — try again after a sync",
+      );
+    }
+    const auth = createAuth(ctx);
+    const headers = await authComponent.getHeaders(ctx);
+    try {
+      await auth.api.unlinkAccount({
+        body: {
+          providerId: connection.provider,
+          accountId: connection.credentialRef,
+        },
+        headers,
+      });
+    } catch (error) {
+      // A grant a previous partial disconnect already revoked is fine — the
+      // point of this call is that it be gone. Anything else aborts before
+      // any data is touched.
+      const message = error instanceof Error ? error.message : String(error);
+      if (!/account.*not.*found/i.test(message)) throw error;
+    }
+    await ctx.runMutation(
+      internal.domains.calendar.mutations.pauseConnectionForRemoval,
+      { connectionId: args.connectionId, userId: user._id },
+    );
+    await ctx.scheduler.runAfter(
+      0,
+      internal.jobs.maintenance.purgeConnectionData,
+      { connectionId: args.connectionId, userId: user._id },
+    );
+    return null;
   },
 });

--- a/packages/backend/convex/domains/calendar/connectionTables.ts
+++ b/packages/backend/convex/domains/calendar/connectionTables.ts
@@ -12,6 +12,11 @@ export const calendarConnectionTables = {
     // The provider account identity (email / tenant), when known. Absent for a
     // backfilled login-grant connection until a sync learns it.
     providerAccountId: v.optional(v.string()),
+    // Cosmetic profile identity for the settings card, decoded from the
+    // provider's stored ID token at link time. Absent until stamped; the card
+    // falls back to the provider's name and logo.
+    providerAccountName: v.optional(v.string()),
+    providerAccountImageUrl: v.optional(v.string()),
     // How the credential broker finds this connection's token (v1: the Better
     // Auth account id). No secret or refresh token lives in app tables.
     credentialRef: v.optional(v.string()),

--- a/packages/backend/convex/domains/calendar/connectionTables.ts
+++ b/packages/backend/convex/domains/calendar/connectionTables.ts
@@ -17,6 +17,10 @@ export const calendarConnectionTables = {
     // falls back to the provider's name and logo.
     providerAccountName: v.optional(v.string()),
     providerAccountImageUrl: v.optional(v.string()),
+    // When the profile fetch last ran, successful or not. A grant whose
+    // profile can't be read (revoked, or a provider that reports no name)
+    // would otherwise be refetched on every single sync.
+    providerIdentityAttemptedAt: v.optional(v.number()),
     // How the credential broker finds this connection's token (v1: the Better
     // Auth account id). No secret or refresh token lives in app tables.
     credentialRef: v.optional(v.string()),

--- a/packages/backend/convex/domains/calendar/connections.ts
+++ b/packages/backend/convex/domains/calendar/connections.ts
@@ -68,6 +68,23 @@ export async function ensureGoogleConnection(
   return connectionId;
 }
 
+/** The deterministic "primary account" among a user's connections: active
+ * first, Google before Microsoft, then the oldest — so the login grant keeps
+ * winning after a second account is linked. Every default-target choice
+ * (event create, booking adoption) must go through this one ordering. */
+export function preferredConnection(
+  connections: Doc<"calendarConnections">[],
+): Doc<"calendarConnections"> | undefined {
+  return connections
+    .filter((row) => row.status === "active")
+    .sort(
+      (a, b) =>
+        Number(b.provider === "google") - Number(a.provider === "google") ||
+        a.createdAt - b.createdAt ||
+        a._creationTime - b._creationTime,
+    )[0];
+}
+
 /** A provider's `primary` alias is writable before CalendarList has synced. */
 export async function ensureDefaultPrimaryCalendar(
   ctx: MutationCtx,

--- a/packages/backend/convex/domains/calendar/mutations.ts
+++ b/packages/backend/convex/domains/calendar/mutations.ts
@@ -113,7 +113,13 @@ export async function reconcileLinkedAccountsHandler(
     userId: string;
     accounts: { credentialRef: string; createdAt: number }[];
   },
-): Promise<{ created: number }> {
+): Promise<{
+  created: number;
+  pendingIdentity: {
+    connectionId: Id<"calendarConnections">;
+    credentialRef: string;
+  }[];
+}> {
   const connections = await ctx.db
     .query("calendarConnections")
     .withIndex("by_user_and_provider", (q) =>
@@ -123,6 +129,20 @@ export async function reconcileLinkedAccountsHandler(
   if (connections.length > 100) {
     throw new Error("Too many connections to reconcile safely");
   }
+  // Rows whose grant is known but whose profile (name/photo) isn't stamped
+  // yet — the caller fetches those from the provider, action-side.
+  const pendingIdentity: {
+    connectionId: Id<"calendarConnections">;
+    credentialRef: string;
+  }[] = [];
+  for (const row of connections) {
+    if (row.credentialRef !== undefined && row.providerAccountName === undefined) {
+      pendingIdentity.push({
+        connectionId: row._id,
+        credentialRef: row.credentialRef,
+      });
+    }
+  }
   const claimed = new Set(
     connections
       .map((row) => row.credentialRef)
@@ -131,7 +151,7 @@ export async function reconcileLinkedAccountsHandler(
   const unclaimed = args.accounts
     .filter((account) => !claimed.has(account.credentialRef))
     .sort((a, b) => a.createdAt - b.createdAt);
-  if (unclaimed.length === 0) return { created: 0 };
+  if (unclaimed.length === 0) return { created: 0, pendingIdentity };
   const now = Date.now();
   const legacy = connections.filter((row) => row.credentialRef === undefined);
   if (legacy.length === 1) {
@@ -140,6 +160,12 @@ export async function reconcileLinkedAccountsHandler(
       credentialRef: oldest.credentialRef,
       updatedAt: now,
     });
+    if (legacy[0].providerAccountName === undefined) {
+      pendingIdentity.push({
+        connectionId: legacy[0]._id,
+        credentialRef: oldest.credentialRef,
+      });
+    }
   }
   let created = 0;
   for (const account of unclaimed) {
@@ -153,9 +179,10 @@ export async function reconcileLinkedAccountsHandler(
       updatedAt: now,
     });
     await ensureConnectionSyncState(ctx, args.userId, connectionId);
+    pendingIdentity.push({ connectionId, credentialRef: account.credentialRef });
     created += 1;
   }
-  return { created };
+  return { created, pendingIdentity };
 }
 
 export const reconcileLinkedAccounts = internalMutation({
@@ -165,8 +192,57 @@ export const reconcileLinkedAccounts = internalMutation({
       v.object({ credentialRef: v.string(), createdAt: v.number() }),
     ),
   },
-  returns: v.object({ created: v.number() }),
+  returns: v.object({
+    created: v.number(),
+    pendingIdentity: v.array(
+      v.object({
+        connectionId: v.id("calendarConnections"),
+        credentialRef: v.string(),
+      }),
+    ),
+  }),
   handler: (ctx, args) => reconcileLinkedAccountsHandler(ctx, args),
+});
+
+/** Best-effort profile stamp from the provider's ID token: the account email
+ * fills `providerAccountId` only when a sync hasn't already, while name and
+ * photo are refreshed whenever the provider reports new ones. */
+export const stampConnectionIdentity = internalMutation({
+  args: {
+    userId: v.string(),
+    connectionId: v.id("calendarConnections"),
+    providerAccountId: v.optional(v.string()),
+    providerAccountName: v.optional(v.string()),
+    providerAccountImageUrl: v.optional(v.string()),
+  },
+  returns: v.null(),
+  handler: async (ctx, args): Promise<null> => {
+    const connection = await ctx.db.get(args.connectionId);
+    if (!connection || connection.userId !== args.userId) return null;
+    const patch: Partial<Doc<"calendarConnections">> = {};
+    if (
+      args.providerAccountId !== undefined &&
+      connection.providerAccountId === undefined
+    ) {
+      patch.providerAccountId = args.providerAccountId;
+    }
+    if (
+      args.providerAccountName !== undefined &&
+      connection.providerAccountName !== args.providerAccountName
+    ) {
+      patch.providerAccountName = args.providerAccountName;
+    }
+    if (
+      args.providerAccountImageUrl !== undefined &&
+      connection.providerAccountImageUrl !== args.providerAccountImageUrl
+    ) {
+      patch.providerAccountImageUrl = args.providerAccountImageUrl;
+    }
+    if (Object.keys(patch).length > 0) {
+      await ctx.db.patch(args.connectionId, { ...patch, updatedAt: Date.now() });
+    }
+    return null;
+  },
 });
 
 /** Take a connection out of the sync fan-out ahead of its purge, so no new

--- a/packages/backend/convex/domains/calendar/mutations.ts
+++ b/packages/backend/convex/domains/calendar/mutations.ts
@@ -15,6 +15,7 @@ import { authComponent } from "../../auth";
 import {
   ensureDefaultPrimaryCalendar,
   ensureGoogleConnection,
+  preferredConnection,
 } from "./connections";
 import { providerEventValidator } from "./validators";
 
@@ -45,7 +46,23 @@ export async function resolveCreateTargetHandler(
     if (calendars.length > 500) {
       throw new Error("Too many calendars to choose a write target safely");
     }
-    calendar = calendars.find((row) => row.primary) ?? null;
+    const primaries = calendars.filter((row) => row.primary);
+    calendar = primaries[0] ?? null;
+    if (primaries.length > 1) {
+      // Several connected accounts each have a `primary` calendar; the
+      // preferred connection's one is the deterministic default.
+      const connections = await ctx.db
+        .query("calendarConnections")
+        .withIndex("by_user", (q) => q.eq("userId", args.userId))
+        .take(101);
+      if (connections.length > 100) {
+        throw new Error("Too many connections to choose a write target safely");
+      }
+      const preferred = preferredConnection(connections);
+      calendar =
+        primaries.find((row) => row.connectionId === preferred?._id) ??
+        primaries[0];
+    }
   }
   if (!calendar && !args.requestedCalendarId) {
     const connectionId = await ensureGoogleConnection(ctx, args.userId);

--- a/packages/backend/convex/domains/calendar/mutations.ts
+++ b/packages/backend/convex/domains/calendar/mutations.ts
@@ -169,6 +169,23 @@ export const reconcileLinkedAccounts = internalMutation({
   handler: (ctx, args) => reconcileLinkedAccountsHandler(ctx, args),
 });
 
+/** Take a connection out of the sync fan-out ahead of its purge, so no new
+ * sync starts against a grant that is about to be (or was just) revoked. */
+export const pauseConnectionForRemoval = internalMutation({
+  args: { userId: v.string(), connectionId: v.id("calendarConnections") },
+  returns: v.null(),
+  handler: async (ctx, args): Promise<null> => {
+    const connection = await ctx.db.get(args.connectionId);
+    if (connection && connection.userId === args.userId) {
+      await ctx.db.patch(args.connectionId, {
+        status: "paused",
+        updatedAt: Date.now(),
+      });
+    }
+    return null;
+  },
+});
+
 /** Resolve neutral event identity before any provider operation. */
 export async function resolveEventWriteTargetHandler(
   ctx: MutationCtx,

--- a/packages/backend/convex/domains/calendar/mutations.ts
+++ b/packages/backend/convex/domains/calendar/mutations.ts
@@ -13,6 +13,7 @@ import {
 } from "../../_generated/server";
 import { authComponent } from "../../auth";
 import {
+  ensureConnectionSyncState,
   ensureDefaultPrimaryCalendar,
   ensureGoogleConnection,
   preferredConnection,
@@ -98,6 +99,74 @@ export const resolveCreateTarget = internalMutation({
     requestedCalendarId: v.optional(v.id("calendars")),
   },
   handler: (ctx, args) => resolveCreateTargetHandler(ctx, args),
+});
+
+/** Bring the connection rows in line with the Google grants Better Auth holds
+ * for the user. Each grant is keyed by `credentialRef` (the provider account
+ * id Better Auth resolves tokens by); a lone pre-linking connection — the
+ * login grant, which predates every link — claims the oldest unclaimed grant
+ * instead of being duplicated. Idempotent: re-running with the same grants
+ * changes nothing. */
+export async function reconcileLinkedAccountsHandler(
+  ctx: MutationCtx,
+  args: {
+    userId: string;
+    accounts: { credentialRef: string; createdAt: number }[];
+  },
+): Promise<{ created: number }> {
+  const connections = await ctx.db
+    .query("calendarConnections")
+    .withIndex("by_user_and_provider", (q) =>
+      q.eq("userId", args.userId).eq("provider", "google"),
+    )
+    .take(101);
+  if (connections.length > 100) {
+    throw new Error("Too many connections to reconcile safely");
+  }
+  const claimed = new Set(
+    connections
+      .map((row) => row.credentialRef)
+      .filter((ref) => ref !== undefined),
+  );
+  const unclaimed = args.accounts
+    .filter((account) => !claimed.has(account.credentialRef))
+    .sort((a, b) => a.createdAt - b.createdAt);
+  if (unclaimed.length === 0) return { created: 0 };
+  const now = Date.now();
+  const legacy = connections.filter((row) => row.credentialRef === undefined);
+  if (legacy.length === 1) {
+    const oldest = unclaimed.shift()!;
+    await ctx.db.patch(legacy[0]._id, {
+      credentialRef: oldest.credentialRef,
+      updatedAt: now,
+    });
+  }
+  let created = 0;
+  for (const account of unclaimed) {
+    const connectionId = await ctx.db.insert("calendarConnections", {
+      userId: args.userId,
+      provider: "google",
+      credentialRef: account.credentialRef,
+      status: "active",
+      capabilities: { contacts: true, idempotentCreate: true },
+      createdAt: now,
+      updatedAt: now,
+    });
+    await ensureConnectionSyncState(ctx, args.userId, connectionId);
+    created += 1;
+  }
+  return { created };
+}
+
+export const reconcileLinkedAccounts = internalMutation({
+  args: {
+    userId: v.string(),
+    accounts: v.array(
+      v.object({ credentialRef: v.string(), createdAt: v.number() }),
+    ),
+  },
+  returns: v.object({ created: v.number() }),
+  handler: (ctx, args) => reconcileLinkedAccountsHandler(ctx, args),
 });
 
 /** Resolve neutral event identity before any provider operation. */

--- a/packages/backend/convex/domains/calendar/mutations.ts
+++ b/packages/backend/convex/domains/calendar/mutations.ts
@@ -24,6 +24,10 @@ import { providerEventValidator } from "./validators";
  * preferences domain's default-calendar validation imports it. */
 export const WRITABLE_ACCESS_ROLES = new Set(["owner", "writer"]);
 const CALENDAR_OPERATION_LEASE_MS = 10 * 60 * 1000;
+/** How long a connection whose profile fetch came back nameless waits before
+ * the next attempt. Without it, an unstampable grant re-fetches a token and
+ * hits userinfo on every user-initiated sync — i.e. every page load. */
+const IDENTITY_RETRY_MS = 24 * 60 * 60 * 1000;
 
 /** Resolve an owned local calendar row to a writable provider target. */
 export async function resolveCreateTargetHandler(
@@ -130,13 +134,20 @@ export async function reconcileLinkedAccountsHandler(
     throw new Error("Too many connections to reconcile safely");
   }
   // Rows whose grant is known but whose profile (name/photo) isn't stamped
-  // yet — the caller fetches those from the provider, action-side.
+  // yet — the caller fetches those from the provider, action-side. A fetch
+  // that came back empty (or threw) still stamps its attempt, so a grant that
+  // can never yield a name is retried daily rather than on every sync.
+  const now = Date.now();
   const pendingIdentity: {
     connectionId: Id<"calendarConnections">;
     credentialRef: string;
   }[] = [];
   for (const row of connections) {
-    if (row.credentialRef !== undefined && row.providerAccountName === undefined) {
+    if (
+      row.credentialRef !== undefined &&
+      row.providerAccountName === undefined &&
+      now - (row.providerIdentityAttemptedAt ?? 0) > IDENTITY_RETRY_MS
+    ) {
       pendingIdentity.push({
         connectionId: row._id,
         credentialRef: row.credentialRef,
@@ -152,7 +163,6 @@ export async function reconcileLinkedAccountsHandler(
     .filter((account) => !claimed.has(account.credentialRef))
     .sort((a, b) => a.createdAt - b.createdAt);
   if (unclaimed.length === 0) return { created: 0, pendingIdentity };
-  const now = Date.now();
   const legacy = connections.filter((row) => row.credentialRef === undefined);
   if (legacy.length === 1) {
     const oldest = unclaimed.shift()!;
@@ -206,7 +216,9 @@ export const reconcileLinkedAccounts = internalMutation({
 
 /** Best-effort profile stamp from the provider's ID token: the account email
  * fills `providerAccountId` only when a sync hasn't already, while name and
- * photo are refreshed whenever the provider reports new ones. */
+ * photo are refreshed whenever the provider reports new ones. Called with no
+ * profile fields when the fetch failed or came back empty — the attempt is
+ * recorded either way, which is what keeps the retry off the sync hot path. */
 export const stampConnectionIdentity = internalMutation({
   args: {
     userId: v.string(),
@@ -219,7 +231,9 @@ export const stampConnectionIdentity = internalMutation({
   handler: async (ctx, args): Promise<null> => {
     const connection = await ctx.db.get(args.connectionId);
     if (!connection || connection.userId !== args.userId) return null;
-    const patch: Partial<Doc<"calendarConnections">> = {};
+    const patch: Partial<Doc<"calendarConnections">> = {
+      providerIdentityAttemptedAt: Date.now(),
+    };
     if (
       args.providerAccountId !== undefined &&
       connection.providerAccountId === undefined
@@ -238,9 +252,7 @@ export const stampConnectionIdentity = internalMutation({
     ) {
       patch.providerAccountImageUrl = args.providerAccountImageUrl;
     }
-    if (Object.keys(patch).length > 0) {
-      await ctx.db.patch(args.connectionId, { ...patch, updatedAt: Date.now() });
-    }
+    await ctx.db.patch(args.connectionId, { ...patch, updatedAt: Date.now() });
     return null;
   },
 });

--- a/packages/backend/convex/domains/calendar/queries.ts
+++ b/packages/backend/convex/domains/calendar/queries.ts
@@ -121,6 +121,8 @@ export async function listConnectionsHandler(ctx: QueryCtx) {
         _id: connection._id,
         provider: connection.provider,
         providerAccountId: connection.providerAccountId,
+        providerAccountName: connection.providerAccountName,
+        providerAccountImageUrl: connection.providerAccountImageUrl,
         status: connection.status,
         contactsEnabled:
           (connection.capabilities?.contacts ?? false) &&
@@ -146,6 +148,8 @@ export const listConnections = query({
       _id: v.id("calendarConnections"),
       provider: v.union(v.literal("google"), v.literal("microsoft")),
       providerAccountId: v.optional(v.string()),
+      providerAccountName: v.optional(v.string()),
+      providerAccountImageUrl: v.optional(v.string()),
       status: v.union(
         v.literal("active"),
         v.literal("paused"),

--- a/packages/backend/convex/domains/calendar/queries.ts
+++ b/packages/backend/convex/domains/calendar/queries.ts
@@ -169,10 +169,14 @@ export const listConnections = query({
 /** Registry lookup that deliberately hides foreign and inactive connections. */
 export async function getCalendarConnectionForAdapterHandler(
   ctx: QueryCtx,
-  args: { connectionId: Id<"calendarConnections"> },
+  args: { connectionId: Id<"calendarConnections">; userId: string },
 ): Promise<Doc<"calendarConnections"> | null> {
   const connection = await ctx.db.get(args.connectionId);
-  if (!connection || connection.status !== "active") {
+  if (
+    !connection ||
+    connection.status !== "active" ||
+    connection.userId !== args.userId
+  ) {
     return null;
   }
   return connection;
@@ -181,6 +185,7 @@ export async function getCalendarConnectionForAdapterHandler(
 export const getCalendarConnectionForAdapter = internalQuery({
   args: {
     connectionId: v.id("calendarConnections"),
+    userId: v.string(),
   },
   handler: (ctx, args) => getCalendarConnectionForAdapterHandler(ctx, args),
 });

--- a/packages/backend/convex/domains/calendar/queries.ts
+++ b/packages/backend/convex/domains/calendar/queries.ts
@@ -190,6 +190,35 @@ export const getCalendarConnectionForAdapter = internalQuery({
   handler: (ctx, args) => getCalendarConnectionForAdapterHandler(ctx, args),
 });
 
+/** Everything disconnectAccount needs to decide: the owned connection (any
+ * status — a paused account can still be removed) and how many same-provider
+ * connections the user holds, since the last one may only be paused. */
+export const getConnectionForRemoval = internalQuery({
+  args: {
+    connectionId: v.id("calendarConnections"),
+    userId: v.string(),
+  },
+  handler: async (
+    ctx,
+    args,
+  ): Promise<{
+    connection: Doc<"calendarConnections">;
+    providerConnectionCount: number;
+  } | null> => {
+    const connection = await ctx.db.get(args.connectionId);
+    if (!connection || connection.userId !== args.userId) {
+      return null;
+    }
+    const siblings = await ctx.db
+      .query("calendarConnections")
+      .withIndex("by_user_and_provider", (q) =>
+        q.eq("userId", args.userId).eq("provider", connection.provider),
+      )
+      .take(101);
+    return { connection, providerConnectionCount: siblings.length };
+  },
+});
+
 /** Events overlapping [startMs, endMs) for the current user, e.g. a week window. */
 export async function listEventsInRangeHandler(
   ctx: QueryCtx,

--- a/packages/backend/convex/domains/calendar/service.ts
+++ b/packages/backend/convex/domains/calendar/service.ts
@@ -112,7 +112,7 @@ async function adapterFor(
 ): Promise<CalendarProviderAdapter> {
   return dependencies?.getAdapter
     ? await dependencies.getAdapter(ctx, userId, connectionId)
-    : await getCalendarAdapter(ctx, connectionId);
+    : await getCalendarAdapter(ctx, userId, connectionId);
 }
 
 async function refreshTarget(

--- a/packages/backend/convex/domains/sync/engine.ts
+++ b/packages/backend/convex/domains/sync/engine.ts
@@ -13,6 +13,7 @@ import { authComponent } from "../../auth";
 import {
   ensureConnectionSyncState,
   ensureGoogleConnection,
+  preferredConnection,
 } from "../calendar/connections";
 import { providerEventValidator } from "../calendar/validators";
 import type {
@@ -723,7 +724,7 @@ async function runConnection(
     // adapter and the feeds no-op.
     const connection: Doc<"calendarConnections"> | null = await ctx.runQuery(
       internal.domains.calendar.queries.getCalendarConnectionForAdapter,
-      { connectionId },
+      { connectionId, userId: state.userId },
     );
     if (!connection) {
       throw new Error("Calendar connection is unavailable");
@@ -1133,14 +1134,7 @@ export const reconcileCalendars = internalMutation({
       if (connections.length > 100) {
         throw new Error("Too many connections to choose a booking target safely");
       }
-      const preferred = connections
-        .filter((row) => row.status === "active")
-        .sort(
-          (a, b) =>
-            Number(b.provider === "google") - Number(a.provider === "google") ||
-            a.createdAt - b.createdAt ||
-            a._creationTime - b._creationTime,
-        )[0];
+      const preferred = preferredConnection(connections);
       if (
         booking &&
         !booking.targetConnectionId &&
@@ -2294,7 +2288,7 @@ export async function refreshConnectionCalendar(
   );
   if (!attemptId) return;
   try {
-    const adapter = await getCalendarAdapter(ctx, connectionId);
+    const adapter = await getCalendarAdapter(ctx, userId, connectionId);
     const calendars: Doc<"calendars">[] = await ctx.runQuery(
       internal.domains.sync.engine.listCalendarsForUser,
       { userId },

--- a/packages/backend/convex/domains/sync/engine.ts
+++ b/packages/backend/convex/domains/sync/engine.ts
@@ -1100,7 +1100,22 @@ export const reconcileCalendars = internalMutation({
           ...patch,
         });
       }
-      if (calendar.primary) primary = id;
+      if (calendar.primary) {
+        primary = id;
+        // Google's primary calendar id is the account email — the cheapest
+        // provider-account identity there is. Stamping it here lazily
+        // backfills connections created before linking existed, so the
+        // settings panel can label every account without a migration.
+        if (
+          connection.provider === "google" &&
+          connection.providerAccountId === undefined
+        ) {
+          await ctx.db.patch(connection._id, {
+            providerAccountId: calendar.id,
+            updatedAt: Date.now(),
+          });
+        }
+      }
       stored.push({
         localCalendarId: id,
         providerCalendarId: calendar.id,

--- a/packages/backend/convex/domains/sync/engine.ts
+++ b/packages/backend/convex/domains/sync/engine.ts
@@ -10,6 +10,7 @@ import {
 } from "../../_generated/server";
 import type { ActionCtx, MutationCtx } from "../../_generated/server";
 import { authComponent } from "../../auth";
+import { reconcileLinkedAccountsForUser } from "../calendar/connectionService";
 import {
   ensureConnectionSyncState,
   ensureGoogleConnection,
@@ -860,6 +861,17 @@ export async function syncNowForCurrentUser(
 ): Promise<UserSyncStatus> {
   const user = await authComponent.safeGetAuthUser(ctx);
   if (!user) throw new Error("Not authenticated");
+  // A user-initiated sync doubles as the linking safety net: a Google grant
+  // that never got its connection row (a missed link redirect) gets one here
+  // and joins the fan-out below.
+  try {
+    await reconcileLinkedAccountsForUser(ctx, user._id);
+  } catch (error) {
+    console.warn(
+      "Linked-account reconcile failed:",
+      error instanceof Error ? error.message : error,
+    );
+  }
   return await runUser(ctx, user._id, true);
 }
 

--- a/packages/backend/convex/integrations/calendar/registry.ts
+++ b/packages/backend/convex/integrations/calendar/registry.ts
@@ -12,11 +12,12 @@ import type { CalendarProviderAdapter } from "./types";
 
 async function connectionForAdapter(
   ctx: GenericCtx<DataModel>,
+  userId: string,
   connectionId: Id<"calendarConnections">,
 ): Promise<Doc<"calendarConnections">> {
   const connection: Doc<"calendarConnections"> | null = await ctx.runQuery(
     internal.domains.calendar.queries.getCalendarConnectionForAdapter,
-    { connectionId },
+    { connectionId, userId },
   );
   if (!connection) {
     throw new Error("Calendar connection is unavailable");
@@ -48,11 +49,12 @@ export async function calendarAdapterFor(
 
 export async function getCalendarAdapter(
   ctx: GenericCtx<DataModel>,
+  userId: string,
   connectionId: Id<"calendarConnections">,
 ): Promise<CalendarProviderAdapter> {
   return await calendarAdapterFor(
     ctx,
-    await connectionForAdapter(ctx, connectionId),
+    await connectionForAdapter(ctx, userId, connectionId),
   );
 }
 
@@ -82,10 +84,11 @@ export async function contactsAdapterFor(
 
 export async function getContactsAdapter(
   ctx: GenericCtx<DataModel>,
+  userId: string,
   connectionId: Id<"calendarConnections">,
 ): Promise<ContactsProviderAdapter | null> {
   return await contactsAdapterFor(
     ctx,
-    await connectionForAdapter(ctx, connectionId),
+    await connectionForAdapter(ctx, userId, connectionId),
   );
 }

--- a/packages/backend/convex/integrations/google/credentials.ts
+++ b/packages/backend/convex/integrations/google/credentials.ts
@@ -16,6 +16,30 @@ import { createAuth } from "../../auth";
  * for provider credentials: when the connection model lands it becomes
  * connection-aware, and today connection == the user's Google login grant.
  */
+/** The account's OpenID profile (email, name, photo) for the settings card.
+ * Fetched from the standard userinfo endpoint rather than decoded from a
+ * stored ID token, which a refresh cycle may not have kept. Best-effort:
+ * a non-OK response is null, never an error. */
+export async function fetchGoogleUserProfile(accessToken: string): Promise<{
+  email?: string;
+  name?: string;
+  picture?: string;
+} | null> {
+  const response = await fetch(
+    "https://www.googleapis.com/oauth2/v3/userinfo",
+    { headers: { Authorization: `Bearer ${accessToken}` } },
+  );
+  if (!response.ok) return null;
+  const data: unknown = await response.json();
+  if (typeof data !== "object" || data === null) return null;
+  const record = data as Record<string, unknown>;
+  return {
+    email: typeof record.email === "string" ? record.email : undefined,
+    name: typeof record.name === "string" ? record.name : undefined,
+    picture: typeof record.picture === "string" ? record.picture : undefined,
+  };
+}
+
 export async function getGoogleAccessToken(
   ctx: GenericCtx<DataModel>,
   userId: string,

--- a/packages/backend/convex/jobs/maintenance.ts
+++ b/packages/backend/convex/jobs/maintenance.ts
@@ -479,6 +479,23 @@ export const purgeConnectionData = internalMutation({
         targetCalendarId: undefined,
       });
     }
+    // A pending request pinned its target when it was made, and acceptance
+    // trusts that pair over the page's — leaving it would fail
+    // validateBookingTarget forever. Cleared, acceptance re-resolves through
+    // the booking page. Terminal bookings keep theirs: they never re-resolve.
+    const pending = await ctx.db
+      .query("bookings")
+      .withIndex("by_host_and_status_and_start", (q) =>
+        q.eq("hostUserId", args.userId).eq("status", "pending"),
+      )
+      .take(PURGE_BATCH);
+    for (const booking of pending) {
+      if (booking.targetConnectionId !== connectionId) continue;
+      await ctx.db.patch(booking._id, {
+        targetConnectionId: undefined,
+        targetCalendarId: undefined,
+      });
+    }
     // People rows may keep a stale source entry pointing at the removed feed;
     // the next contacts sync re-ranks them, so they're deliberately left alone.
     const connection = await ctx.db.get(connectionId);

--- a/packages/backend/convex/jobs/maintenance.ts
+++ b/packages/backend/convex/jobs/maintenance.ts
@@ -355,3 +355,136 @@ export const purgeUserData = internalMutation({
     return { done: true };
   },
 });
+
+/** Disconnect-an-account purge: everything a single connection synced, in the
+ * same batched self-rescheduling shape as purgeUserData, followed by the
+ * pointer fixups (default calendar, booking-page target) and finally the
+ * connection row itself. The sibling connections' data is untouched. */
+export const purgeConnectionData = internalMutation({
+  args: { connectionId: v.id("calendarConnections"), userId: v.string() },
+  returns: v.object({ done: v.boolean() }),
+  handler: async (ctx, args): Promise<{ done: boolean }> => {
+    const connectionId = args.connectionId;
+    let more = false;
+    const drain = async (rows: { _id: Id<TableNames> }[]): Promise<void> => {
+      for (const row of rows) {
+        await ctx.db.delete(row._id);
+      }
+      if (rows.length === PURGE_BATCH) {
+        more = true;
+      }
+    };
+
+    // Children before the parent connection row, same as purgeUserData: a
+    // retry never observes connection-owned state without its connection.
+    await drain(
+      await ctx.db
+        .query("connectionSyncState")
+        .withIndex("by_connection", (q) => q.eq("connectionId", connectionId))
+        .take(PURGE_BATCH),
+    );
+    await drain(
+      await ctx.db
+        .query("calendarOperations")
+        .withIndex("by_connection_and_key", (q) =>
+          q.eq("connectionId", connectionId),
+        )
+        .take(PURGE_BATCH),
+    );
+    await drain(
+      await ctx.db
+        .query("contacts")
+        .withIndex("by_connection_and_providerContactId", (q) =>
+          q.eq("connectionId", connectionId),
+        )
+        .take(PURGE_BATCH),
+    );
+    await drain(
+      await ctx.db
+        .query("otherContactSources")
+        .withIndex("by_connection_and_providerContactId", (q) =>
+          q.eq("connectionId", connectionId),
+        )
+        .take(PURGE_BATCH),
+    );
+    await drain(
+      await ctx.db
+        .query("personSourceClaims")
+        .withIndex("by_connection_and_source_and_email", (q) =>
+          q.eq("connectionId", connectionId),
+        )
+        .take(PURGE_BATCH),
+    );
+    await drain(
+      await ctx.db
+        .query("events")
+        .withIndex("by_connection_and_localCalendarId_and_providerEventId", (q) =>
+          q.eq("connectionId", connectionId),
+        )
+        .take(PURGE_BATCH),
+    );
+    await drain(
+      await ctx.db
+        .query("recurringSeries")
+        .withIndex("by_connection_and_localCalendarId_and_providerEventId", (q) =>
+          q.eq("connectionId", connectionId),
+        )
+        .take(PURGE_BATCH),
+    );
+    await drain(
+      await ctx.db
+        .query("calendars")
+        .withIndex("by_connection_and_providerCalendarId", (q) =>
+          q.eq("connectionId", connectionId),
+        )
+        .take(PURGE_BATCH),
+    );
+
+    if (more) {
+      await ctx.scheduler.runAfter(
+        0,
+        internal.jobs.maintenance.purgeConnectionData,
+        args,
+      );
+      return { done: false };
+    }
+
+    // Final batch: repoint anything that referenced the removed data. A
+    // preference for one of this connection's calendars now dangles — clearing
+    // it lets the preferred connection's primary take over. A booking page
+    // targeting this connection is likewise cleared; the next reconcile
+    // re-adopts a target from a surviving connection.
+    const prefs = await ctx.db
+      .query("userPreferences")
+      .withIndex("by_user", (q) => q.eq("userId", args.userId))
+      .unique();
+    if (
+      prefs?.defaultCalendarId &&
+      (await ctx.db.get(prefs.defaultCalendarId)) === null
+    ) {
+      await ctx.db.patch(prefs._id, {
+        defaultCalendarId: undefined,
+        updatedAt: Date.now(),
+      });
+    }
+    const pages = await ctx.db
+      .query("bookingPages")
+      .withIndex("by_targetConnectionId_and_targetCalendarId", (q) =>
+        q.eq("targetConnectionId", connectionId),
+      )
+      .take(PURGE_BATCH);
+    for (const page of pages) {
+      await ctx.db.patch(page._id, {
+        targetConnectionId: undefined,
+        targetCalendarId: undefined,
+      });
+    }
+    // People rows may keep a stale source entry pointing at the removed feed;
+    // the next contacts sync re-ranks them, so they're deliberately left alone.
+    const connection = await ctx.db.get(connectionId);
+    if (connection && connection.userId === args.userId) {
+      await ctx.db.delete(connectionId);
+    }
+    return { done: true };
+  },
+});

--- a/packages/backend/tests/domains/calendar/connections.itest.ts
+++ b/packages/backend/tests/domains/calendar/connections.itest.ts
@@ -83,7 +83,11 @@ describe("connection model", () => {
       internal.domains.calendar.mutations.reconcileLinkedAccounts,
       { userId, accounts },
     );
-    expect(first).toEqual({ created: 1 });
+    expect(first.created).toBe(1);
+    // Both rows now know their grant but not their profile yet.
+    expect(
+      first.pendingIdentity.map((p) => p.credentialRef).sort(),
+    ).toEqual(["google-sub-linked", "google-sub-login"]);
     // The oldest grant is the login one; it claims the legacy row.
     expect(
       (await t.run((ctx) => ctx.db.get(legacyId)))?.credentialRef,
@@ -110,12 +114,58 @@ describe("connection model", () => {
           .unique(),
       ),
     ).toMatchObject({ status: "idle", nextSyncDueAt: 0 });
-    // Re-running with the same grants is a no-op.
+    // Re-running with the same grants creates nothing, but keeps reporting
+    // the unstamped profiles until stampConnectionIdentity fills them.
     const second = await t.mutation(
       internal.domains.calendar.mutations.reconcileLinkedAccounts,
       { userId, accounts },
     );
-    expect(second).toEqual({ created: 0 });
+    expect(second.created).toBe(0);
+    expect(second.pendingIdentity).toHaveLength(2);
+    await t.mutation(
+      internal.domains.calendar.mutations.stampConnectionIdentity,
+      {
+        userId,
+        connectionId: linked!._id,
+        providerAccountId: "linked@example.com",
+        providerAccountName: "Linked Account",
+        providerAccountImageUrl: "https://example.com/a.png",
+      },
+    );
+    expect(await t.run((ctx) => ctx.db.get(linked!._id))).toMatchObject({
+      providerAccountId: "linked@example.com",
+      providerAccountName: "Linked Account",
+      providerAccountImageUrl: "https://example.com/a.png",
+    });
+    // A foreign stamp is refused, and a sync-stamped email is never replaced.
+    await t.mutation(
+      internal.domains.calendar.mutations.stampConnectionIdentity,
+      {
+        userId: "someone_else",
+        connectionId: linked!._id,
+        providerAccountName: "Hijacked",
+      },
+    );
+    await t.mutation(
+      internal.domains.calendar.mutations.stampConnectionIdentity,
+      {
+        userId,
+        connectionId: linked!._id,
+        providerAccountId: "other@example.com",
+        providerAccountName: "Linked Renamed",
+      },
+    );
+    expect(await t.run((ctx) => ctx.db.get(linked!._id))).toMatchObject({
+      providerAccountId: "linked@example.com",
+      providerAccountName: "Linked Renamed",
+    });
+    const third = await t.mutation(
+      internal.domains.calendar.mutations.reconcileLinkedAccounts,
+      { userId, accounts },
+    );
+    expect(third.pendingIdentity.map((p) => p.credentialRef)).toEqual([
+      "google-sub-login",
+    ]);
     expect(
       await t.run(async (ctx) =>
         (

--- a/packages/backend/tests/domains/calendar/connections.itest.ts
+++ b/packages/backend/tests/domains/calendar/connections.itest.ts
@@ -29,24 +29,35 @@ describe("connection model", () => {
     expect(
       await t.query(internal.domains.calendar.queries.getCalendarConnectionForAdapter, {
         connectionId,
+        userId: "owner",
       }),
     ).toMatchObject({ credentialRef: "account-1", provider: "google" });
+    // A foreign caller never sees the connection, even while it is active.
+    expect(
+      await t.query(internal.domains.calendar.queries.getCalendarConnectionForAdapter, {
+        connectionId,
+        userId: "someone_else",
+      }),
+    ).toBeNull();
     await t.run((ctx) => ctx.db.patch(connectionId, { status: "paused" }));
     expect(
       await t.query(internal.domains.calendar.queries.getCalendarConnectionForAdapter, {
         connectionId,
+        userId: "owner",
       }),
     ).toBeNull();
     await t.run((ctx) => ctx.db.patch(connectionId, { status: "error" }));
     expect(
       await t.query(internal.domains.calendar.queries.getCalendarConnectionForAdapter, {
         connectionId,
+        userId: "owner",
       }),
     ).toBeNull();
     await t.run((ctx) => ctx.db.delete(connectionId));
     expect(
       await t.query(internal.domains.calendar.queries.getCalendarConnectionForAdapter, {
         connectionId,
+        userId: "owner",
       }),
     ).toBeNull();
   });

--- a/packages/backend/tests/domains/calendar/connections.itest.ts
+++ b/packages/backend/tests/domains/calendar/connections.itest.ts
@@ -62,6 +62,72 @@ describe("connection model", () => {
     ).toBeNull();
   });
 
+  test("linked-account reconcile stamps the login grant and creates the rest once", async () => {
+    const t = convexTest(schema, modules);
+    const userId = "user_link";
+    // The pre-linking bootstrap connection: no credentialRef yet.
+    const legacyId = await t.run((ctx) =>
+      ctx.db.insert("calendarConnections", {
+        userId,
+        provider: "google",
+        status: "active",
+        createdAt: 1,
+        updatedAt: 1,
+      }),
+    );
+    const accounts = [
+      { credentialRef: "google-sub-linked", createdAt: 2_000 },
+      { credentialRef: "google-sub-login", createdAt: 1_000 },
+    ];
+    const first = await t.mutation(
+      internal.domains.calendar.mutations.reconcileLinkedAccounts,
+      { userId, accounts },
+    );
+    expect(first).toEqual({ created: 1 });
+    // The oldest grant is the login one; it claims the legacy row.
+    expect(
+      (await t.run((ctx) => ctx.db.get(legacyId)))?.credentialRef,
+    ).toBe("google-sub-login");
+    const connections = await t.run((ctx) =>
+      ctx.db
+        .query("calendarConnections")
+        .withIndex("by_user", (q) => q.eq("userId", userId))
+        .collect(),
+    );
+    expect(connections).toHaveLength(2);
+    const linked = connections.find(
+      (row) => row.credentialRef === "google-sub-linked",
+    );
+    expect(linked).toMatchObject({ provider: "google", status: "active" });
+    // The new connection starts with clean sync state.
+    expect(
+      await t.run((ctx) =>
+        ctx.db
+          .query("connectionSyncState")
+          .withIndex("by_connection", (q) =>
+            q.eq("connectionId", linked!._id),
+          )
+          .unique(),
+      ),
+    ).toMatchObject({ status: "idle", nextSyncDueAt: 0 });
+    // Re-running with the same grants is a no-op.
+    const second = await t.mutation(
+      internal.domains.calendar.mutations.reconcileLinkedAccounts,
+      { userId, accounts },
+    );
+    expect(second).toEqual({ created: 0 });
+    expect(
+      await t.run(async (ctx) =>
+        (
+          await ctx.db
+            .query("calendarConnections")
+            .withIndex("by_user", (q) => q.eq("userId", userId))
+            .collect()
+        ).length,
+      ),
+    ).toBe(2);
+  });
+
   test("a connection links its sync-state and operation rows", async () => {
     const t = convexTest(schema, modules);
     const userId = "user_conn";

--- a/packages/backend/tests/domains/calendar/connections.itest.ts
+++ b/packages/backend/tests/domains/calendar/connections.itest.ts
@@ -382,3 +382,57 @@ describe("connection model", () => {
     ).rejects.toThrow("Calendar not found");
   });
 });
+
+describe("default create target with several accounts", () => {
+  test("resolves to the oldest active connection's primary, unless one is requested", async () => {
+    const t = convexTest(schema, modules);
+    const userId = "user_two_primaries";
+    const seed = async (key: string, createdAt: number) =>
+      await t.run(async (ctx) => {
+        const connectionId = await ctx.db.insert("calendarConnections", {
+          userId,
+          provider: "google",
+          credentialRef: `sub-${key}`,
+          status: "active",
+          createdAt,
+          updatedAt: createdAt,
+        });
+        const calendarId = await ctx.db.insert("calendars", {
+          userId,
+          connectionId,
+          providerCalendarId: `${key}@example.com`,
+          primary: true,
+          accessRole: "owner",
+          selected: true,
+          isShared: false,
+        });
+        return { connectionId, calendarId };
+      });
+    // Inserted linked-first so document order can't accidentally pass the test.
+    const linked = await seed("linked", 2);
+    const login = await seed("login", 1);
+
+    const byDefault = await t.mutation(
+      internal.domains.calendar.mutations.resolveCreateTarget,
+      { userId },
+    );
+    expect(byDefault.connectionId).toEqual(login.connectionId);
+    expect(byDefault.localCalendarId).toEqual(login.calendarId);
+
+    const requested = await t.mutation(
+      internal.domains.calendar.mutations.resolveCreateTarget,
+      { userId, requestedCalendarId: linked.calendarId },
+    );
+    expect(requested.connectionId).toEqual(linked.connectionId);
+
+    // Pausing the login connection hands the default to the linked account.
+    await t.run((ctx) =>
+      ctx.db.patch(login.connectionId, { status: "paused" }),
+    );
+    const afterPause = await t.mutation(
+      internal.domains.calendar.mutations.resolveCreateTarget,
+      { userId },
+    );
+    expect(afterPause.connectionId).toEqual(linked.connectionId);
+  });
+});

--- a/packages/backend/tests/domains/calendar/connections.test.ts
+++ b/packages/backend/tests/domains/calendar/connections.test.ts
@@ -1,0 +1,64 @@
+// @ts-expect-error Bun supplies its test module at runtime.
+import { describe, expect, test } from "bun:test";
+
+import type { Doc } from "../../../convex/_generated/dataModel";
+import { preferredConnection } from "../../../convex/domains/calendar/connections";
+
+function conn(
+  id: string,
+  over: Partial<Doc<"calendarConnections">> = {},
+): Doc<"calendarConnections"> {
+  return {
+    _id: id,
+    _creationTime: 0,
+    userId: "user",
+    provider: "google",
+    status: "active",
+    createdAt: 0,
+    updatedAt: 0,
+    ...over,
+  } as Doc<"calendarConnections">;
+}
+
+describe("preferredConnection", () => {
+  test("is empty-safe and skips inactive connections", () => {
+    expect(preferredConnection([])).toBeUndefined();
+    expect(
+      preferredConnection([conn("paused", { status: "paused" })]),
+    ).toBeUndefined();
+    expect(
+      preferredConnection([
+        conn("paused", { status: "paused", createdAt: 1 }),
+        conn("active", { createdAt: 2 }),
+      ])?._id,
+    ).toBe("active");
+  });
+
+  test("prefers Google, then the oldest connection", () => {
+    expect(
+      preferredConnection([
+        conn("ms", { provider: "microsoft", createdAt: 1 }),
+        conn("google", { createdAt: 2 }),
+      ])?._id,
+    ).toBe("google");
+    // The login grant predates a linked account, so it stays preferred.
+    expect(
+      preferredConnection([
+        conn("linked", { createdAt: 2 }),
+        conn("login", { createdAt: 1 }),
+      ])?._id,
+    ).toBe("login");
+    expect(
+      preferredConnection([
+        conn("b", { createdAt: 1, _creationTime: 2 } as never),
+        conn("a", { createdAt: 1, _creationTime: 1 } as never),
+      ])?._id,
+    ).toBe("a");
+  });
+
+  test("does not mutate its input order", () => {
+    const rows = [conn("second", { createdAt: 2 }), conn("first", { createdAt: 1 })];
+    preferredConnection(rows);
+    expect(rows.map((row) => row._id)).toEqual(["second", "first"]);
+  });
+});

--- a/packages/backend/tests/domains/sync/engine.itest.ts
+++ b/packages/backend/tests/domains/sync/engine.itest.ts
@@ -392,6 +392,30 @@ describe("connection identity and lease fencing", () => {
     expect(repatched?.selected).toBe(false);
   });
 
+  test("reconciliation stamps the account identity from the primary calendar once", async () => {
+    const t = convexTest(schema, modules);
+    const userId = "reconcile-identity";
+    const connectionId = await setupConnection(t, userId, "google");
+    const attemptId = await t.mutation(internal.domains.sync.engine.claimSyncLease, {
+      connectionId,
+    });
+    const reconcile = (primaryId: string) =>
+      t.mutation(internal.domains.sync.engine.reconcileCalendars, {
+        connectionId,
+        attemptId: attemptId!,
+        calendars: [{ id: primaryId, writable: true, primary: true }],
+      });
+    await reconcile("owner@example.com");
+    expect(
+      (await t.run((ctx) => ctx.db.get(connectionId)))?.providerAccountId,
+    ).toBe("owner@example.com");
+    // A connection that already knows its identity is never re-stamped.
+    await reconcile("renamed@example.com");
+    expect(
+      (await t.run((ctx) => ctx.db.get(connectionId)))?.providerAccountId,
+    ).toBe("owner@example.com");
+  });
+
   test("event upserts key on connection, local calendar, and provider event id", async () => {
     const t = convexTest(schema, modules);
     const userId = "neutral-upsert";

--- a/packages/backend/tests/domains/sync/engine.itest.ts
+++ b/packages/backend/tests/domains/sync/engine.itest.ts
@@ -594,7 +594,9 @@ describe("connection-aware contact ownership", () => {
         capabilities: { contacts: false, idempotentCreate: true },
       }),
     );
-    expect(await getContactsAdapter(testActionCtx(t), connectionId)).toBeNull();
+    expect(
+      await getContactsAdapter(testActionCtx(t), "no-contacts-user", connectionId),
+    ).toBeNull();
   });
 
   test("removing one connection's contact keeps another claim for the same email", async () => {

--- a/packages/backend/tests/jobs/maintenance.itest.ts
+++ b/packages/backend/tests/jobs/maintenance.itest.ts
@@ -321,3 +321,203 @@ describe("calendar operation retention", () => {
     expect(await t.run((ctx) => ctx.db.get(operationId))).not.toBeNull();
   });
 });
+
+describe("purgeConnectionData", () => {
+  const seedConnection = async (
+    t: ReturnType<typeof convexTest>,
+    userId: string,
+    key: string,
+  ) =>
+    await t.run(async (ctx) => {
+      const connectionId = await ctx.db.insert("calendarConnections", {
+        userId,
+        provider: "google",
+        credentialRef: `sub-${key}`,
+        status: "active",
+        createdAt: 1,
+        updatedAt: 1,
+      });
+      await ctx.db.insert("connectionSyncState", {
+        connectionId,
+        userId,
+        status: "idle",
+      });
+      await ctx.db.insert("calendarOperations", {
+        connectionId,
+        userId,
+        idempotencyKey: `op-${key}`,
+        kind: "create",
+        status: "pending",
+        createdAt: 1,
+        updatedAt: 1,
+      });
+      const calendarId = await ctx.db.insert("calendars", {
+        userId,
+        connectionId,
+        providerCalendarId: `cal-${key}`,
+        selected: true,
+        isShared: false,
+      });
+      await ctx.db.insert("events", {
+        userId,
+        connectionId,
+        localCalendarId: calendarId,
+        providerEventId: `event-${key}`,
+        providerUpdatedMs: 1,
+        startMs: 1,
+        endMs: 2,
+        allDay: false,
+        status: "confirmed",
+      });
+      await ctx.db.insert("recurringSeries", {
+        userId,
+        connectionId,
+        localCalendarId: calendarId,
+        providerEventId: `event-${key}`,
+        providerUpdatedMs: 1,
+        recurrence: ["RRULE:FREQ=DAILY"],
+      });
+      await ctx.db.insert("contacts", {
+        userId,
+        connectionId,
+        providerContactId: `contact-${key}`,
+        emails: [`${key}@example.com`],
+        phones: [],
+      });
+      await ctx.db.insert("otherContactSources", {
+        userId,
+        connectionId,
+        providerContactId: `other-${key}`,
+        emails: [`${key}@example.com`],
+      });
+      await ctx.db.insert("personSourceClaims", {
+        userId,
+        connectionId,
+        providerContactId: `contact-${key}`,
+        email: `${key}@example.com`,
+        source: "connection",
+        updatedAt: 1,
+      });
+      return { connectionId, calendarId };
+    });
+
+  test("erases one connection's rows, repoints defaults, spares the sibling", async () => {
+    const t = convexTest(schema, modules);
+    const userId = "splitter";
+    const doomed = await seedConnection(t, userId, "doomed");
+    const kept = await seedConnection(t, userId, "kept");
+    await t.run(async (ctx) => {
+      await ctx.db.insert("userPreferences", {
+        userId,
+        defaultCalendarId: doomed.calendarId,
+        updatedAt: 1,
+      });
+      await ctx.db.insert("bookingPages", {
+        userId,
+        slug: "splitter",
+        displayName: "Splitter",
+        timeZone: "UTC",
+        slotMinutes: 30,
+        bufferMinutes: 0,
+        minNoticeMinutes: 0,
+        horizonDays: 14,
+        rules: [],
+        enabled: true,
+        targetConnectionId: doomed.connectionId,
+        targetCalendarId: doomed.calendarId,
+      });
+    });
+
+    const res = await t.mutation(internal.jobs.maintenance.purgeConnectionData, {
+      connectionId: doomed.connectionId,
+      userId,
+    });
+    expect(res.done).toBe(true);
+
+    await t.run(async (ctx) => {
+      expect(await ctx.db.get(doomed.connectionId)).toBeNull();
+      expect(await ctx.db.get(kept.connectionId)).not.toBeNull();
+      for (const table of [
+        "connectionSyncState",
+        "calendarOperations",
+        "calendars",
+        "events",
+        "recurringSeries",
+        "contacts",
+        "otherContactSources",
+        "personSourceClaims",
+      ] as const) {
+        const rows = await ctx.db.query(table).collect();
+        expect(rows).toHaveLength(1);
+        expect(rows[0].connectionId).toEqual(kept.connectionId);
+      }
+      const prefs = await ctx.db.query("userPreferences").unique();
+      expect(prefs?.defaultCalendarId).toBeUndefined();
+      const page = await ctx.db.query("bookingPages").unique();
+      expect(page?.targetConnectionId).toBeUndefined();
+      expect(page?.targetCalendarId).toBeUndefined();
+    });
+  });
+
+  test("a default calendar on a surviving connection is left alone", async () => {
+    const t = convexTest(schema, modules);
+    const userId = "keeper";
+    const doomed = await seedConnection(t, userId, "doomed");
+    const kept = await seedConnection(t, userId, "kept");
+    await t.run(async (ctx) => {
+      await ctx.db.insert("userPreferences", {
+        userId,
+        defaultCalendarId: kept.calendarId,
+        updatedAt: 1,
+      });
+    });
+    const res = await t.mutation(internal.jobs.maintenance.purgeConnectionData, {
+      connectionId: doomed.connectionId,
+      userId,
+    });
+    expect(res.done).toBe(true);
+    expect(
+      (await t.run((ctx) => ctx.db.query("userPreferences").unique()))
+        ?.defaultCalendarId,
+    ).toEqual(kept.calendarId);
+  });
+
+  test("a full batch reports more work and finishes on the retry", async () => {
+    // Fake timers park the self-reschedule so each pass runs explicitly.
+    vi.useFakeTimers();
+    const t = convexTest(schema, modules);
+    const userId = "bulk";
+    const doomed = await seedConnection(t, userId, "doomed");
+    await t.run(async (ctx) => {
+      for (let i = 0; i < 100; i++) {
+        await ctx.db.insert("events", {
+          userId,
+          connectionId: doomed.connectionId,
+          localCalendarId: doomed.calendarId,
+          providerEventId: `bulk-${i}`,
+          providerUpdatedMs: 1,
+          startMs: i,
+          endMs: i + 1,
+          allDay: false,
+          status: "confirmed",
+        });
+      }
+    });
+    const first = await t.mutation(internal.jobs.maintenance.purgeConnectionData, {
+      connectionId: doomed.connectionId,
+      userId,
+    });
+    expect(first.done).toBe(false);
+    expect(
+      await t.run((ctx) => ctx.db.get(doomed.connectionId)),
+    ).not.toBeNull();
+    const second = await t.mutation(internal.jobs.maintenance.purgeConnectionData, {
+      connectionId: doomed.connectionId,
+      userId,
+    });
+    expect(second.done).toBe(true);
+    expect(await t.run((ctx) => ctx.db.get(doomed.connectionId))).toBeNull();
+    expect(await t.run((ctx) => ctx.db.query("events").collect())).toHaveLength(0);
+    vi.useRealTimers();
+  });
+});


### PR DESCRIPTION
## What

One user can now connect additional Google accounts and have their calendars sync and merge into the existing view — plus the full lifecycle: per-account identity in settings, account-grouped pickers, and a disconnect path that revokes the grant and purges everything it synced.

PR #13 left the backend provider-ready (connection-keyed tables, per-connection sync fan-out, a credential broker that already accepted an `accountId`); this PR fills the linking gaps.

## How

**Linking.** Better Auth account linking is enabled (`allowDifferentEmails`, trusted `google`), and Settings → Accounts gains an *Add Google account* button that starts `linkSocial` — the existing provider config already carries `accessType: "offline"` + consent prompt + calendar/contacts scopes, so linked grants get full-scope refresh tokens. Landing back with `?linked=google` runs the new `connectLinkedAccounts` action, which diffs Better Auth's Google grants against `calendarConnections` by `credentialRef` (the Google `sub` — what `getAccessToken` routes tokens by), creates missing rows with clean sync state, and kicks a first sync. A user-initiated sync runs the same reconcile as a safety net for missed redirects.

**Backfill with no migration.** A lone pre-linking connection claims the oldest grant (the login one predates every link), `reconcileCalendars` stamps `providerAccountId` from the Google primary-calendar id (which *is* the account email), and the reconcile stamps each grant's profile (name, photo) from Google's `userinfo` endpoint via the credential broker — decoding the stored ID token (Better Auth `accountInfo`) turned out to return nothing for grants whose refresh cycle didn't keep one.

**Determinism.** The preferred-connection ordering that `reconcileCalendars` already used (active → Google → oldest) is extracted into `preferredConnection` and now backs every default-target choice: event create, booking target, booking-page adoption, and the client-side preview (`pickPrimaryCalendar`). Two connections each carrying a `primary: true` calendar can no longer race for the default; the original login account keeps winning.

**Disconnect.** `disconnectAccount` requires a second same-provider connection (the sole account can only be paused — disconnecting it would strand the login), unlinks the Better Auth grant first so the reconcile can't resurrect the connection, pauses it out of the sync fan-out, then `purgeConnectionData` batch-drains everything the connection synced (events, series, calendars, contact feeds, claims, sync state, operations) and clears a dangling default-calendar preference or booking-page target. Settings shows a two-step *Disconnect* per extra account.

**Security.** `getCalendarConnectionForAdapter` now requires the caller's `userId` and hides foreign connections — its docstring claimed this but the check was missing, and multi-account puts more connection ids in circulation.

**UI.** The header calendar picker and the event form's calendar popover group calendars under account emails once a second connection exists (two calendars named "Personal" stay tellable apart). The settings card resolves the *Primary* identity treatment by matching the stamped account email to the session, so it survives linking; linked accounts show their own name and photo. Also fixes the settings pane's scroll fade on Firefox (no scroll-driven animations there — a JS fallback drives the mask custom properties; inert where the CSS animation exists).

## Verified

- Backend: `tsc` + 138 unit / 79 integration tests (reconcile idempotency + legacy stamping, two-account create-target determinism incl. paused login, foreign-connection adapter refusal, purge batching + fixups + sibling isolation, identity stamping).
- Live on the dev deployment: a real second account was linked end-to-end — its calendars synced and merged, and all three existing users' connections were backfilled with `credentialRef`, email, name, and photo with no migration.

## Notes for reviewers

- Signing in at the login page with the *second* account's email creates a separate user — users must sign in with their original account (inherent to linking).
- Expected noise: one "No session found" error log per link callback, from the crossDomain plugin (link callbacks mint no session).
- `session.freshAge: 0` disables Better Auth's session-freshness gate; login is OAuth-only, so there is no cheap re-auth to satisfy it and `unlinkAccount` would otherwise reject day-old sessions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)