### PR TITLE
Fix three rough edges in availability editing

### DIFF
--- a/apps/web/src/components/calendar/availability-block.tsx
+++ b/apps/web/src/components/calendar/availability-block.tsx
@@ -3,6 +3,7 @@ import { HugeiconsIcon } from "@hugeicons/react";
 import type { DayInterval } from "@qali/domain/availability";
 import { cn } from "@qali/ui/lib/utils";
 import { motion, useReducedMotion } from "motion/react";
+import { useEffect, useRef, useState } from "react";
 
 import { usePreferences } from "@/components/workspace/preferences-context";
 import {
@@ -11,6 +12,11 @@ import {
   MS_PER_MINUTE,
 } from "./lib";
 
+/** How long one shimmer band takes to cross a block. Every sweep now runs to
+ * its end, so this is a floor on how long a save appears to take — short enough
+ * that a write landing early isn't held up, long enough to read as a sweep. */
+const SWEEP_SECONDS = 0.55;
+
 /**
  * One painted availability span on the time grid, shown only while setting
  * availability. Green so it reads as "open" next to the neutral event cards and
@@ -18,7 +24,11 @@ import {
  *
  * `saving` is the middle state between drawing and the write landing: the block
  * is already on the grid (drawn optimistically) but a shimmer sweeps across it
- * until the override is committed, so a span never blinks out and back.
+ * until the override is committed, so a span never blinks out and back. The
+ * write usually lands mid-sweep — on a local deployment, barely into it — so
+ * `saving` only ever *opens* the shimmer; a sweep already travelling always
+ * runs to its end. Cutting the band off halfway across reads as a glitch
+ * rather than as the write completing.
  *
  * `data-availability` opts it out of the column's paint-drag: a pointer down on
  * a block edits the block instead of starting a new selection.
@@ -36,6 +46,15 @@ export function AvailabilityBlock({
 }) {
   const reduce = useReducedMotion();
   const { use24h } = usePreferences();
+  // One sweep per cycle rather than `repeat: Infinity`, so each has an end to
+  // wait for; `cycle` remounts the band to send it across again.
+  const [sweeping, setSweeping] = useState(saving === true);
+  const [cycle, setCycle] = useState(0);
+  const savingRef = useRef(saving);
+  useEffect(() => {
+    savingRef.current = saving;
+    if (saving) setSweeping(true);
+  }, [saving]);
   const startMs = dayStartMs + interval.startMin * MS_PER_MINUTE;
   const endMs = dayStartMs + interval.endMin * MS_PER_MINUTE;
   const topPct = msToPct(startMs, dayStartMs);
@@ -58,25 +77,35 @@ export function AvailabilityBlock({
       )}
       style={{ top: `${topPct}%`, height: `${Math.max(heightPct, 0)}%` }}
     >
-      {saving &&
-        (reduce ? (
-          <span
-            aria-hidden
-            className="pointer-events-none absolute inset-0 animate-pulse bg-chart-2/10"
-          />
-        ) : (
-          <motion.span
-            aria-hidden
-            className="pointer-events-none absolute inset-y-0 -inset-x-1"
-            style={{
-              background:
-                "linear-gradient(100deg, transparent 30%, color-mix(in oklab, var(--chart-2) 40%, transparent) 50%, transparent 70%)",
-            }}
-            initial={{ x: "-60%" }}
-            animate={{ x: "60%" }}
-            transition={{ repeat: Infinity, duration: 1.15, ease: "easeInOut" }}
-          />
-        ))}
+      {/* Reduced motion keeps the plain pulse and stops it the moment the write
+          lands: asking for less animation is not asking to wait for one. */}
+      {reduce
+        ? saving && (
+            <span
+              aria-hidden
+              className="pointer-events-none absolute inset-0 animate-pulse bg-chart-2/10"
+            />
+          )
+        : sweeping && (
+            <motion.span
+              key={cycle}
+              aria-hidden
+              className="pointer-events-none absolute inset-y-0 -inset-x-1"
+              style={{
+                background:
+                  "linear-gradient(100deg, transparent 30%, color-mix(in oklab, var(--chart-2) 40%, transparent) 50%, transparent 70%)",
+              }}
+              initial={{ x: "-60%" }}
+              animate={{ x: "60%" }}
+              transition={{ duration: SWEEP_SECONDS, ease: "easeInOut" }}
+              onAnimationComplete={() => {
+                // Still writing, so send another band across; otherwise that
+                // was the last one and it crossed the whole block.
+                if (savingRef.current) setCycle((c) => c + 1);
+                else setSweeping(false);
+              }}
+            />
+          )}
       <span className="relative flex w-full items-start justify-between gap-1 px-1.5 py-0.5">
         <span className="min-w-0 truncate text-[11px] leading-tight font-medium text-chart-2">
           {formatWallClockMinutes(interval.startMin, false, use24h)} –{" "}

--- a/apps/web/src/components/calendar/day-column.tsx
+++ b/apps/web/src/components/calendar/day-column.tsx
@@ -145,6 +145,10 @@ function DayColumnImpl({
   const onKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
     if (!canEditDay || e.target !== e.currentTarget) return;
     if (e.key === "Enter") {
+      // Enter commits the draft, so it must never fire on a draft that isn't
+      // on screen: a paint drag leaves this column focused, and blind-adding
+      // the default 9:00 span from that state would be a nasty surprise.
+      if (!keyboardActive) return;
       e.preventDefault();
       addInterval(
         day,
@@ -155,6 +159,9 @@ function DayColumnImpl({
     }
     if (e.key !== "ArrowUp" && e.key !== "ArrowDown") return;
     e.preventDefault();
+    // Arrowing is how someone who focused this column with a pointer reaches
+    // the keyboard draft, so it raises the draft as well as moving it.
+    setKeyboardActive(true);
     const delta = e.key === "ArrowUp" ? -SNAP_MINUTES : SNAP_MINUTES;
     setKeyboardDraft((current) => {
       if (e.shiftKey) {
@@ -180,7 +187,12 @@ function DayColumnImpl({
       onPointerDown={onPointerDown}
       onKeyDown={onKeyDown}
       onFocus={(e) => {
-        if (e.target === e.currentTarget) setKeyboardActive(true);
+        if (e.target !== e.currentTarget) return;
+        // A paint drag focuses this column too — the browser runs that default
+        // action *after* onPointerDown, so clearing the flag there can't hold.
+        // `:focus-visible` is the browser's own answer to "did this focus come
+        // from the keyboard", and only that kind should raise the draft.
+        setKeyboardActive(e.currentTarget.matches(":focus-visible"));
       }}
       onBlur={(e) => {
         if (!e.currentTarget.contains(e.relatedTarget)) setKeyboardActive(false);

--- a/apps/web/src/components/workspace/availability-panel.test.ts
+++ b/apps/web/src/components/workspace/availability-panel.test.ts
@@ -1,0 +1,76 @@
+// @ts-expect-error Bun supplies its test module at runtime; the web app's
+// TypeScript config intentionally includes browser globals only.
+import { describe, expect, test } from "bun:test";
+
+process.env.SKIP_ENV_VALIDATION = "1";
+const { bookingSaveBlockedReason } = await import("./availability-panel");
+
+/** A draft that saves cleanly, so each case below changes exactly one thing. */
+const ok = {
+  saving: false,
+  openRuleCount: 5,
+  slug: "nat",
+  slugUnchanged: false,
+  check: { available: true, reason: null },
+} as const;
+
+describe("bookingSaveBlockedReason", () => {
+  test("says nothing when the draft is savable", () => {
+    expect(bookingSaveBlockedReason({ ...ok })).toBeNull();
+  });
+
+  test("stays quiet mid-save so the spinner speaks instead", () => {
+    expect(bookingSaveBlockedReason({ ...ok, saving: true })).toBeNull();
+  });
+
+  test("names the closed week before anything else", () => {
+    expect(bookingSaveBlockedReason({ ...ok, openRuleCount: 0 })).toBe(
+      "Open at least one day",
+    );
+  });
+
+  test("reports a slug the mutation would reject, in its own words", () => {
+    expect(bookingSaveBlockedReason({ ...ok, slug: "na" })).toBe(
+      "Use at least 3 characters",
+    );
+    expect(bookingSaveBlockedReason({ ...ok, slug: "settings" })).toBe(
+      "That name is reserved",
+    );
+  });
+
+  // An unchanged slug skips the availability query, so a pending `check` there
+  // is the steady state, not a wait.
+  test("does not wait on a check that will never run", () => {
+    expect(
+      bookingSaveBlockedReason({
+        ...ok,
+        slugUnchanged: true,
+        check: undefined,
+      }),
+    ).toBeNull();
+  });
+
+  test("waits on an availability check that is still in flight", () => {
+    expect(bookingSaveBlockedReason({ ...ok, check: undefined })).toBe(
+      "Checking that link name…",
+    );
+  });
+
+  test("passes the server's reason through when the name is taken", () => {
+    expect(
+      bookingSaveBlockedReason({
+        ...ok,
+        check: { available: false, reason: "That link is already taken" },
+      }),
+    ).toBe("That link is already taken");
+  });
+
+  test("falls back to its own copy when the server gives no reason", () => {
+    expect(
+      bookingSaveBlockedReason({
+        ...ok,
+        check: { available: false, reason: null },
+      }),
+    ).toBe("That link name is taken");
+  });
+});

--- a/apps/web/src/components/workspace/availability-panel.tsx
+++ b/apps/web/src/components/workspace/availability-panel.tsx
@@ -10,7 +10,7 @@ import {
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { api } from "@qali/backend/convex/_generated/api";
-import { normalizeSlug } from "@qali/domain/slug";
+import { normalizeSlug, slugError } from "@qali/domain/slug";
 import { Button } from "@qali/ui/components/button";
 import { Input } from "@qali/ui/components/input";
 import { Switch } from "@qali/ui/components/switch";
@@ -152,6 +152,43 @@ function NumberStepper({
       </Button>
     </div>
   );
+}
+
+/** Why per-date painting is blocked before anything has been saved. The gate is
+ * *saved*, not *live*: a saved page that is paused paints just fine. */
+const UNSAVED_PAGE_REASON =
+  "Save your booking link first, then you can override single days";
+
+/**
+ * Why a booking-page save can't run, in the host's terms — or null when nothing
+ * blocks it.
+ *
+ * A save already in flight reports null: the button's own spinner says that
+ * better than a tooltip would. `slugError` is the same validator the mutation
+ * rejects with, so a name the server would refuse is refused in the same words
+ * here rather than in a second, drifting set of copy.
+ */
+export function bookingSaveBlockedReason(state: {
+  saving: boolean;
+  /** Weekly openings that survived validation — what `canSave` counts. */
+  openRuleCount: number;
+  /** The slug as normalized, not as typed. */
+  slug: string;
+  /** Whether the slug still matches the one already persisted, in which case
+   * there is no availability check in flight to wait on. */
+  slugUnchanged: boolean;
+  check: { available: boolean; reason: string | null } | undefined;
+}): string | null {
+  if (state.saving) return null;
+  if (state.openRuleCount === 0) return "Open at least one day";
+  const slugProblem = slugError(state.slug);
+  if (slugProblem) return slugProblem;
+  if (state.slugUnchanged) return null;
+  if (state.check === undefined) return "Checking that link name…";
+  if (!state.check.available) {
+    return state.check.reason ?? "That link name is taken";
+  }
+  return null;
 }
 
 /**
@@ -318,6 +355,19 @@ function AvailabilityForm({
   const slugReady =
     normalized.length >= 3 && (slugUnchanged || check?.available === true);
   const canSave = slugReady && rules.length > 0 && !saving;
+  const saveBlockedReason = bookingSaveBlockedReason({
+    saving,
+    openRuleCount: rules.length,
+    slug: normalized,
+    slugUnchanged,
+    check,
+  });
+  // Per-date overrides need a page to hang off, so an unsaved draft blocks them
+  // even when everything else is valid. Being *live* is not required — a saved
+  // but paused page paints fine.
+  const dateEditorBlocked = page === null || !canSave;
+  const dateEditorBlockedReason =
+    page === null ? UNSAVED_PAGE_REASON : saveBlockedReason;
   const origin = typeof window === "undefined" ? "" : window.location.origin;
   const publicUrl = `${origin}/${normalized}`;
   const variants = reduce ? dockVariantsReduced : dockVariants;
@@ -662,34 +712,52 @@ function AvailabilityForm({
             </div>
 
             {/* Per-date painting overrides individual days on the calendar; it
-                needs a saved page, so it's gated until one exists. */}
-            <button
-              type="button"
-              disabled={page === null || !canSave}
-              onClick={() => void openDateEditor()}
-              className="group flex items-center gap-3 rounded-2xl bg-muted/60 px-3 py-2.5 text-left outline-none transition-colors hover:bg-muted focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:bg-muted/60"
-            >
-              <HugeiconsIcon
-                icon={Calendar03Icon}
-                strokeWidth={2}
-                className="size-5 shrink-0 text-muted-foreground"
+                needs a saved page, so it's gated until one exists. The gate is
+                `aria-disabled` rather than `disabled` so the button still takes
+                a hover and a focus and can say why it won't open — a natively
+                disabled element emits no pointer events, and the tooltip would
+                never fire. The click guard, not the browser, is what blocks it. */}
+            <Tooltip>
+              <TooltipTrigger
+                render={
+                  <button
+                    type="button"
+                    aria-disabled={dateEditorBlocked}
+                    onClick={() => {
+                      if (dateEditorBlocked) return;
+                      void openDateEditor();
+                    }}
+                    className="group flex items-center gap-3 rounded-2xl bg-muted/60 px-3 py-2.5 text-left outline-none transition-colors hover:bg-muted focus-visible:ring-2 focus-visible:ring-ring aria-disabled:cursor-not-allowed aria-disabled:opacity-50 aria-disabled:hover:bg-muted/60"
+                  >
+                    <HugeiconsIcon
+                      icon={Calendar03Icon}
+                      strokeWidth={2}
+                      className="size-5 shrink-0 text-muted-foreground"
+                    />
+                    <span className="flex min-w-0 flex-1 flex-col">
+                      <span className="text-sm font-medium">
+                        Set specific dates
+                      </span>
+                      <span className="truncate text-xs text-muted-foreground">
+                        {page === null
+                          ? "Save your link first to override single days"
+                          : zoneChanged
+                            ? `Saving moves your published hours to ${timeZone.replace(/_/g, " ")} time`
+                            : "Save these settings, then paint individual days"}
+                      </span>
+                    </span>
+                    <HugeiconsIcon
+                      icon={ArrowRight01Icon}
+                      strokeWidth={2}
+                      className="size-4 shrink-0 text-muted-foreground transition-transform group-hover:translate-x-0.5"
+                    />
+                  </button>
+                }
               />
-              <span className="flex min-w-0 flex-1 flex-col">
-                <span className="text-sm font-medium">Set specific dates</span>
-                <span className="truncate text-xs text-muted-foreground">
-                  {page === null
-                    ? "Save your link first to override single days"
-                    : zoneChanged
-                      ? `Saving moves your published hours to ${timeZone.replace(/_/g, " ")} time`
-                      : "Save these settings, then paint individual days"}
-                </span>
-              </span>
-              <HugeiconsIcon
-                icon={ArrowRight01Icon}
-                strokeWidth={2}
-                className="size-4 shrink-0 text-muted-foreground transition-transform group-hover:translate-x-0.5"
-              />
-            </button>
+              {dateEditorBlockedReason && (
+                <TooltipContent>{dateEditorBlockedReason}</TooltipContent>
+              )}
+            </Tooltip>
 
             <div className="space-y-1.5">
               <p className="px-2 text-xs font-medium text-muted-foreground">
@@ -801,16 +869,37 @@ function AvailabilityForm({
                   </span>
                 </span>
               </label>
-              <Button
-                type="button"
-                size="sm"
-                disabled={!canSave}
-                className={cn(saving && "opacity-80")}
-                onClick={() => void persist(true)}
-              >
-                {saving && <Spinner />}
-                {saving ? "Saving…" : "Save"}
-              </Button>
+              {/* This is where the button above sends the host, so it has to
+                  explain itself too. `focusableWhenDisabled` is Base UI's own
+                  version of the trick used there: it marks the button
+                  `aria-disabled` instead of natively disabled — so it keeps
+                  emitting the pointer events the tooltip needs — while still
+                  swallowing the click. The `disabled:` variants in
+                  `buttonVariants` key off the native attribute and so no longer
+                  match, hence the `aria-disabled:` ones here. */}
+              <Tooltip>
+                <TooltipTrigger
+                  render={
+                    <Button
+                      type="button"
+                      size="sm"
+                      disabled={!canSave}
+                      focusableWhenDisabled
+                      className={cn(
+                        "aria-disabled:cursor-not-allowed aria-disabled:opacity-50 aria-disabled:hover:bg-primary",
+                        saving && "opacity-80",
+                      )}
+                      onClick={() => void persist(true)}
+                    >
+                      {saving && <Spinner />}
+                      {saving ? "Saving…" : "Save"}
+                    </Button>
+                  }
+                />
+                {saveBlockedReason && (
+                  <TooltipContent>{saveBlockedReason}</TooltipContent>
+                )}
+              </Tooltip>
             </div>
           </motion.div>
         )}


### PR DESCRIPTION
Three separate defects found while investigating a report that the custom-availability drawer was "disabled, something to do with the timezone mismatch".

**It was not a timezone mismatch.** `zoneChanged` is `page !== null && page.timeZone !== timeZone`, so it is `false` in exactly the state being hit. The dev deployment simply has no `bookingPages` row, so `page === null` gated the button off — and the greyed control explained nothing, which is how it got mistaken for a zone bug.

### Say why the booking-link buttons are disabled

"Set specific dates" is gated on a saved page, Save on a valid draft; neither said which. Both now carry a tooltip naming the actual blocker, from one exported reason table so the two can't drift. It defers to `slugError` — the validator the mutation itself rejects with — rather than growing a second set of copy for the same rules.

A natively `disabled` element emits no pointer events, so a tooltip on one never fires. "Set specific dates" moves to `aria-disabled` + a click guard; Save uses Base UI's `focusableWhenDisabled`, which does the same thing and swallows the click for us. Both keep their tab stop, so the explanation reaches the keyboard too.

Worth noting for reviewers: the gate is **saved**, not **live**. A saved-but-paused page paints specific dates fine, so the copy says "save", not "make it live".

### Keep the keyboard draft out of a paint drag

Releasing a paint drag left a dashed 9:00–9:15 ghost on the column. The column is focusable while painting, so the pointer focuses it — and the browser runs that default action *after* `onPointerDown`, so clearing the flag there could never hold. Focus now raises the draft only on `:focus-visible`.

The sharper edge was Enter: it committed the draft regardless of how the column got focus, so a keypress after a paint drag would have written an unseen 9:00 span. It now requires the draft to be on screen.

### Let a painted span's shimmer finish its sweep

The shimmer ran on `repeat: Infinity` and was torn down the moment the write landed — locally, barely out of the gate — so the band vanished mid-travel. Each sweep is now its own animation with an end to wait for. Since every sweep runs to completion its duration is a floor on perceived save time, so it drops 1.15s → 0.55s.

## Verification

- Typecheck, full suite (120 tests, 8 new), and production build green.
- All four `aria-disabled:` utilities confirmed present in the **production** CSS with correct `[aria-disabled=true]` selectors — this repo has a history of classes being purged.
- Base UI's tooltip `disabled` is its own prop and never inspects the DOM attribute, so `aria-disabled` does not suppress it.
- `:focus-visible` behaviour confirmed empirically with real input: mouse click on a `tabIndex=0` div → `false`; Tab key → `true`.

**Not verified in a running authenticated app** — the sandboxed browser has no session. The three visual behaviours want a manual pass: hover the greyed button, drag a span and confirm no 9:00 ghost appears, and confirm the shimmer crosses the block once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)