### PR TITLE
Opaque dock surface, assistant panel padding, and a mock assistant mode

### DIFF
--- a/apps/web/src/components/workspace/assistant-dock.tsx
+++ b/apps/web/src/components/workspace/assistant-dock.tsx
@@ -182,7 +182,9 @@ export function AssistantDock() {
           // The notification panel inherits the goo surface's resolved colour.
           // Bridge that same palette into semantic tokens for the assistant's
           // bubbles, cards and composer instead of relying on the page theme.
-          <div className="goo-panel-theme h-full">
+          // The goo shell's own 6px of padding is menu-tier; a content panel
+          // needs real margins, so the breathing room lives here.
+          <div className="goo-panel-theme h-full p-2.5">
             <AssistantPanelLoader
               threadId={threadId}
               onThreadChange={selectThread}

--- a/apps/web/src/components/workspace/bottom-island.tsx
+++ b/apps/web/src/components/workspace/bottom-island.tsx
@@ -296,7 +296,7 @@ export function BottomIsland() {
           willChange: "transform",
         }}
         className={cn(
-          "pointer-events-auto overflow-hidden border border-border bg-popover/90 shadow-lg backdrop-blur",
+          "pointer-events-auto overflow-hidden border border-black/20 bg-white shadow-lg dark:border-border dark:bg-popover",
           // The edit bar is a pill sized to its own content, like the nav row.
           // Settings carries its own inset so its two-tone sidebar can run
           // edge to edge (the panel restores the padding on small screens).

--- a/apps/web/src/components/workspace/workspace-skeleton.tsx
+++ b/apps/web/src/components/workspace/workspace-skeleton.tsx
@@ -144,7 +144,7 @@ export function WorkspaceSkeleton() {
         aria-hidden
         className="pointer-events-none fixed inset-x-0 bottom-6 z-50 flex justify-center px-4"
       >
-        <div className="flex items-center gap-1 rounded-[28px] border border-border bg-popover/90 px-2 py-1.5 shadow-lg backdrop-blur">
+        <div className="flex items-center gap-1 rounded-[28px] border border-black/20 bg-white px-2 py-1.5 shadow-lg dark:border-border dark:bg-popover">
           <Skeleton className="size-9 rounded-lg" />
           <Skeleton className="size-9 rounded-lg" />
           <Skeleton className="size-9 rounded-lg" />

--- a/packages/backend/convex/domains/assistant/loop.ts
+++ b/packages/backend/convex/domains/assistant/loop.ts
@@ -145,6 +145,12 @@ function requireApiKey(): string {
   return key;
 }
 
+/** Dev stand-in. Setting DEEPSEEK_API_KEY to this literal keeps the panel
+ * enabled, but a turn never leaves the deployment: the loop streams a canned
+ * reply instead of calling DeepSeek, so the panel can be exercised — and its
+ * UI worked on — without a real key. */
+const MOCK_API_KEY = "mock";
+
 // --- History ---------------------------------------------------------------
 
 /** What became of a proposal, in the words the model should read. */
@@ -279,6 +285,10 @@ async function runAgentLoop(
     nowMs: number;
   },
 ): Promise<FollowUpContext | null> {
+  if (run.apiKey === MOCK_API_KEY) {
+    return runMockTurn(ctx, run);
+  }
+
   const client = new OpenAI({
     apiKey: run.apiKey,
     baseURL: DEEPSEEK_BASE_URL,
@@ -475,6 +485,37 @@ async function runAgentLoop(
   return null;
 }
 
+/** The mock turn: the canned reply rides the same flushText path the real
+ * stream uses, in a few timed chunks, so the panel renders it indistinguishably
+ * from a live model — that fidelity is the whole point of the mock. */
+async function runMockTurn(
+  ctx: ActionCtx,
+  run: {
+    assistantMessageId: Id<"assistantMessages">;
+    userText: string;
+  },
+): Promise<FollowUpContext | null> {
+  const chunks = [
+    `**Mock mode** — no model is connected, so I can't see your calendar. `,
+    `You asked:\n\n> ${run.userText.slice(0, 200)}\n\n`,
+    `A real reply would read something like:\n\n`,
+    `- **Standup** — 9:00 to 9:15 AM\n`,
+    `- **Deep work** — 10:00 AM to 12:00 PM\n`,
+    `- **Design review** — 2:00 to 3:00 PM\n\n`,
+    `Set a real \`DEEPSEEK_API_KEY\` on the deployment to bring me to life.`,
+  ];
+  let text = "";
+  for (const chunk of chunks) {
+    text += chunk;
+    await ctx.runMutation(internal.domains.assistant.data.flushText, {
+      messageId: run.assistantMessageId,
+      text,
+    });
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  }
+  return { userText: run.userText, assistantText: text };
+}
+
 /** The follow-up generator's frozen instruction. Kept lean and strict: the panel
  * only ever wants a short JSON array, and most turns should yield none. */
 const FOLLOWUP_SYSTEM = `You suggest what the user of a calendar scheduling assistant might naturally ask next.
@@ -490,6 +531,13 @@ async function generateFollowUps(
   apiKey: string,
   context: FollowUpContext,
 ): Promise<string[]> {
+  if (apiKey === MOCK_API_KEY) {
+    return [
+      "What's on my calendar tomorrow?",
+      "Find 30 minutes for a call",
+      "Move my next meeting an hour later",
+    ];
+  }
   const client = new OpenAI({ apiKey, baseURL: DEEPSEEK_BASE_URL });
   const body = {
     model: MODEL,


### PR DESCRIPTION
## What

Three small polish/devex changes:

- **Dock surface** — the bottom island (and its skeleton twin) now uses an opaque white surface with a firmer `black/20` border in light mode instead of the translucent `bg-popover/90` + `backdrop-blur`, which read muddy over the calendar grid. Dark mode keeps the existing tokens.
- **Assistant panel padding** — the goo shell's 6px inset is sized for menus, so the assistant's header, conversation and composer sat nearly flush with the panel edge. The panel wrapper now carries `p-2.5` of its own; menu-style dropdowns (month picker, notifications) are untouched.
- **Mock assistant mode** — setting `DEEPSEEK_API_KEY=mock` on a deployment keeps the panel enabled but streams a canned markdown reply through the same `flushText` path as a real DeepSeek stream (plus fixed follow-up chips). Lets the panel UI be developed against a dev deployment without a real key; any other key value takes the normal path untouched.

## Testing

- Verified on a fresh Convex dev deployment with a real Google Calendar account: dock renders with the new surface in all views, assistant mock streams in chunks with markdown (bold, blockquote, bullets, inline code) and shows follow-up chips.
- Proposal/confirm cards are not covered by the mock (they need real tool calls) — mock mode only exercises text streaming and chips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VEYDqseskhAwo5xuUfn5o9