### PR TITLE
Draw the dock hairline as a ring that stays 1px through the layout spring

### DIFF
--- a/apps/web/src/components/workspace/assistant-dock.tsx
+++ b/apps/web/src/components/workspace/assistant-dock.tsx
@@ -25,6 +25,7 @@ import {
   isEditableAssistantShortcutTarget,
   shouldOpenAssistantShortcut,
 } from "./assistant-interactions";
+import { useTheme } from "@/components/theme-provider";
 import { MascotGlyph } from "./mascot-glyph";
 
 type Threads = FunctionReturnType<typeof api.domains.assistant.data.listThreads>;
@@ -161,6 +162,12 @@ export function AssistantDock() {
     }
   }, [threadId, deleteThread]);
 
+  // The FAB shares the bottom dock's surface: opaque white in light, the
+  // popover surface in dark. The goo fill is one CSS string, so the theme is
+  // resolved here rather than via `dark:` classes.
+  const { resolvedTheme } = useTheme();
+  const restingFill = resolvedTheme === "light" ? "#fff" : "var(--popover)";
+
   if (!assistantAvailable) return null;
 
   const trigger = <MascotGlyph className="size-6" active={menuOpen} />;
@@ -215,13 +222,13 @@ export function AssistantDock() {
         panelRadius={20}
         // Resting: a neutral FAB on the app surface. Open: it morphs into the
         // inverted primary surface, matching the notification panel's flip.
-        fill="var(--popover)"
+        fill={restingFill}
         foreground="var(--popover-foreground)"
         hoverFill="var(--accent)"
         activeFill="var(--primary)"
         activeForeground="var(--primary-foreground)"
         activeHoverFill="color-mix(in oklch, var(--primary-foreground) 14%, var(--primary))"
-        triggerClassName="mascot-trigger !size-12 !px-0 rounded-full border border-border shadow-lg"
+        triggerClassName="mascot-trigger !size-12 !px-0 rounded-full shadow-lg ring ring-black/20 dark:ring-white/15"
       />
     </div>
   );

--- a/apps/web/src/components/workspace/bottom-island.tsx
+++ b/apps/web/src/components/workspace/bottom-island.tsx
@@ -16,7 +16,13 @@ import {
 } from "@qali/ui/components/tooltip";
 import { cn } from "@qali/ui/lib/utils";
 import { useQuery } from "convex/react";
-import { AnimatePresence, motion, useReducedMotion } from "motion/react";
+import {
+  addScaleCorrector,
+  AnimatePresence,
+  motion,
+  type MotionStyle,
+  useReducedMotion,
+} from "motion/react";
 import { lazy, Suspense, useEffect, useRef, useState } from "react";
 
 import { EventCreate } from "@/components/calendar/event-create";
@@ -41,6 +47,27 @@ import { SettingsPanelSkeleton } from "./settings-skeleton";
 
 const MAX_TIMEOUT_MS = 2_147_000_000;
 const AVAILABILITY_PREFETCH_GRACE_MS = 10_000;
+
+/** The dock's hairline is a ring (box-shadow), not a border. Motion's layout
+ * spring transform-scales the box each frame and corrects `borderRadius` to
+ * compensate, but it has no border-width corrector, so a real border visibly
+ * thickens and thins as the spring settles. A ring's spread can be corrected:
+ * divide it back out of the frame's scale. Tailwind's `ring` utility still
+ * supplies the composed `box-shadow` and `--tw-ring-color`; the nav passes
+ * this one var through `style` so motion owns it and rewrites it per frame. */
+const RING_SHADOW_REST = "0 0 0 1px var(--tw-ring-color)";
+addScaleCorrector({
+  "--tw-ring-shadow": {
+    correct: (_latest, { treeScale, projectionDelta }) => {
+      if (!treeScale || !projectionDelta) return RING_SHADOW_REST;
+      const scale =
+        (projectionDelta.x.scale * treeScale.x +
+          projectionDelta.y.scale * treeScale.y) /
+        2;
+      return `0 0 0 ${1 / scale}px var(--tw-ring-color)`;
+    },
+  },
+});
 
 /** Settings is the dock's heaviest panel by far, so it loads as its own chunk
  * instead of riding in the dock's synchronous module graph (the assistant
@@ -290,12 +317,17 @@ export function BottomIsland() {
         data-dock-view-transition="bottom-island"
         // Plain style, not `animate` — `layout` rewrites borderRadius each frame
         // to correct for the box scaling, and an animated value fights that.
-        style={{
-          borderRadius: editing ? 28 : cornerRadius(view),
-          willChange: "transform",
-        }}
+        style={
+          {
+            borderRadius: editing ? 28 : cornerRadius(view),
+            "--tw-ring-shadow": RING_SHADOW_REST,
+            willChange: "transform",
+            // MotionStyle doesn't type custom properties, but motion does
+            // forward them (and scale-corrects this one; see the corrector).
+          } as MotionStyle
+        }
         className={cn(
-          "pointer-events-auto overflow-hidden border border-black/20 bg-white shadow-lg dark:border-border dark:bg-popover",
+          "pointer-events-auto overflow-hidden bg-white shadow-lg ring ring-black/20 dark:bg-popover dark:ring-white/15",
           // The edit bar is a pill sized to its own content, like the nav row.
           // Settings carries its own inset so its two-tone sidebar can run
           // edge to edge (the panel restores the padding on small screens).

--- a/apps/web/src/components/workspace/workspace-skeleton.tsx
+++ b/apps/web/src/components/workspace/workspace-skeleton.tsx
@@ -144,7 +144,7 @@ export function WorkspaceSkeleton() {
         aria-hidden
         className="pointer-events-none fixed inset-x-0 bottom-6 z-50 flex justify-center px-4"
       >
-        <div className="flex items-center gap-1 rounded-[28px] border border-black/20 bg-white px-2 py-1.5 shadow-lg dark:border-border dark:bg-popover">
+        <div className="flex items-center gap-1 rounded-[28px] bg-white px-2 py-1.5 shadow-lg ring ring-black/20 dark:bg-popover dark:ring-white/15">
           <Skeleton className="size-9 rounded-lg" />
           <Skeleton className="size-9 rounded-lg" />
           <Skeleton className="size-9 rounded-lg" />


### PR DESCRIPTION
## Summary

- The dock, its skeleton pill and the assistant FAB now draw their hairline as a Tailwind `ring` (box-shadow) instead of a CSS border.
- Motion's layout spring transform-scales the dock each frame; it corrects `borderRadius` but has no border-width corrector, so the old border thickened and thinned through the spring. A ring's spread can be corrected: `bottom-island.tsx` registers an `addScaleCorrector` for `--tw-ring-shadow` and passes the resting value through the nav's `style`, so motion rewrites it per frame and it settles at exactly 1px at rest.
- The FAB takes the dock's surface and hairline (white / black-20 in light) instead of the popover fill and 6% border, so the two match.
- Dark mode uses a 15% white ring; the 5% border token was invisible between the #1b1b1b dock and the #111111 page.

## Test plan

- [x] Typecheck clean for the touched files (the pre-existing `main.tsx` auth-client error is untouched).
- [x] Scratch probe of the corrector on a slow layout spring, sampled every frame in Chrome: ring spread tracks the inverse of the scale and returns to `0 0 0 1px` at rest.
- [x] Real dock in the dev app computes `border-width: 0` with the 1px ring composed ahead of the drop shadow.
- [ ] Eyeball light and dark: dock, skeleton pill and FAB share one hairline weight and surface; open/close a panel and confirm the hairline no longer swells during the spring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
