### PR TITLE
Pin the "Use weekly" pill under the day header while the grid scrolls

### DIFF
--- a/apps/web/src/components/calendar/day-column.tsx
+++ b/apps/web/src/components/calendar/day-column.tsx
@@ -254,14 +254,24 @@ function DayColumnImpl({
         ))}
       </div>
       {availability?.isOverride && (
-        <button
-          type="button"
-          data-availability
-          onClick={() => resetDay(day)}
-          className="absolute top-1 right-1 z-40 rounded-md bg-background/90 px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground shadow-sm ring-1 ring-border hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-        >
-          Use weekly
-        </button>
+        // An in-flow sticky rail (the column's only in-flow child; everything
+        // else is absolute) pins the pill just under the day header as the
+        // grid scrolls and lets go at the column's bottom edge. Its `top`
+        // transitions on the header's own 200ms clock so the pill rides the
+        // all-day band as it expands or collapses, and it sits *below* the
+        // header (z-30) so any drift between the two hides under the header
+        // instead of painting over it. Click-through except for the pill
+        // itself, so a paint drag can still start beside it.
+        <div className="pointer-events-none sticky top-[var(--calendar-header-height)] z-[25] flex justify-end px-1 pt-1 transition-[top] duration-200 motion-reduce:transition-none">
+          <button
+            type="button"
+            data-availability
+            onClick={() => resetDay(day)}
+            className="pointer-events-auto rounded-md bg-background/90 px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground shadow-sm ring-1 ring-border hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          >
+            Use weekly
+          </button>
+        </div>
       )}
       {availability?.intervals.map((interval, index) => (
         <AvailabilityBlock

--- a/apps/web/src/components/calendar/time-strip.tsx
+++ b/apps/web/src/components/calendar/time-strip.tsx
@@ -1,6 +1,7 @@
 import { api } from "@qali/backend/convex/_generated/api";
 import { useQuery } from "convex/react";
 import {
+  type CSSProperties,
   forwardRef,
   useCallback,
   useEffect,
@@ -19,6 +20,7 @@ import {
   bucketDayEvents,
   dayColsTemplate,
   GUTTER_TOTAL,
+  HEADER_DATE_HEIGHT,
   layoutAllDayEvents,
   MIN_DAY_HEIGHT,
   MS_PER_DAY,
@@ -579,14 +581,21 @@ export const TimeStrip = forwardRef<TimeStripHandle, TimeStripProps>(
             data-time-grid
             ref={bodyRef}
             className="relative grid flex-1 bg-background"
-            style={{
-              gridTemplateColumns: dayColsTemplate(days.length),
-              gridTemplateRows: "minmax(0, 1fr)",
-              minHeight: MIN_DAY_HEIGHT,
-              backgroundImage:
-                "linear-gradient(to bottom, color-mix(in oklab, var(--border) 55%, transparent) 0 1px, transparent 1px)",
-              backgroundSize: "100% calc(100% / 24)",
-            }}
+            style={
+              {
+                // The sticky header's live height, for anything in a column
+                // that wants to pin itself just underneath it (the "Use
+                // weekly" rail in DayColumn). A variable rather than a prop so
+                // an all-day toggle doesn't re-render every memoized column.
+                "--calendar-header-height": `${HEADER_DATE_HEIGHT + allDayHeight}px`,
+                gridTemplateColumns: dayColsTemplate(days.length),
+                gridTemplateRows: "minmax(0, 1fr)",
+                minHeight: MIN_DAY_HEIGHT,
+                backgroundImage:
+                  "linear-gradient(to bottom, color-mix(in oklab, var(--border) 55%, transparent) 0 1px, transparent 1px)",
+                backgroundSize: "100% calc(100% / 24)",
+              } as CSSProperties
+            }
           >
             {days.map((day, i) => (
               <DayColumn


### PR DESCRIPTION
## What

While editing availability, a day with a per-date override shows a small "Use weekly" pill to reset it back to the weekly schedule. It was `absolute top-1 right-1` inside the full-height day column, so it sat at 00:00 and disappeared as soon as you scrolled down.

It now stays pinned just under the day header at the top-right of its column for as long as that day is on screen.

## How

- **`time-strip.tsx`**: the time grid publishes the sticky header's live height (date row + all-day band) as `--calendar-header-height`. This is the only inline style; the height is a runtime number that changes when the all-day band expands. A CSS variable rather than a prop keeps the memoized `DayColumn`s from re-rendering on that toggle.
- **`day-column.tsx`**: the button moved into an in-flow sticky rail, all Tailwind: `sticky top-[var(--calendar-header-height)] z-[25]` with `transition-[top] duration-200` matching the header's own height transition, so the pill slides with the all-day band. The rail is `pointer-events-none` (only the pill is hittable) so paint drags still start beside it, and `data-availability` stays on the button so a pointer-down on it never starts a paint.

## Reviewer notes

- Z-index dropped from 40 to 25 on purpose: the header wrapper is `z-30` in the same stacking context, so the old value would have painted the pill over the header. At 25 it sits above availability blocks and the now-line (`z-20`) and below the header, so any transition drift hides under the header.
- No `left` on the sticky element, so it does not pin horizontally during day paging.
- Verified the compiled utility on the running dev server and the pinning / horizontal / hit-test / header-resize behaviour on a scratch page mirroring the strip DOM. Not exercised end to end in the signed-in app; to check: enter availability editing, paint an interval so "Use weekly" appears, and scroll down.
- `tsc` reports one pre-existing error in `src/main.tsx` (Better Auth client type), unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
