### PR TITLE
Document Web Push keys as optional setup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,7 +94,27 @@ cd ../..
 The assistant never writes to your calendar on its own — it proposes a change
 and waits for you to confirm it in the dock.
 
-## 5. Run, verify, and open a PR
+## 5. Configure Web Push for reminders (optional)
+
+Event reminders work without any extra setup: they show as in-app
+notifications and, while a qali tab is open, as browser notifications. Web
+Push — reminders arriving when qali is closed — needs a VAPID key pair on the
+deployment. Without one, the "Browser notifications" switch in Preferences is
+simply hidden and everything else works.
+
+```bash
+cd packages/backend
+bunx web-push generate-vapid-keys     # prints a public and a private key
+bunx convex env set VAPID_PUBLIC_KEY "<public-key>"
+bunx convex env set VAPID_PRIVATE_KEY "<private-key>"
+bunx convex env set VAPID_SUBJECT "mailto:<your-email>"   # or an https: URL
+cd ../..
+```
+
+Each deployment needs its own pair; rotating a key invalidates every browser
+subscription made against it (they re-subscribe on their next visit).
+
+## 6. Run, verify, and open a PR
 
 ```bash
 bun run dev          # start everything; open http://localhost:3001

--- a/packages/backend/.env.example
+++ b/packages/backend/.env.example
@@ -20,3 +20,10 @@ GOOGLE_CLIENT_SECRET=your-google-client-secret
 #   npx convex env set CONVEX_SITE_URL https://<your-deployment>.convex.site
 #   npx convex env set GOOGLE_CLIENT_ID <id>
 #   npx convex env set GOOGLE_CLIENT_SECRET <secret>
+
+# Optional: Web Push for event reminders when qali is closed. Without these
+# the "Browser notifications" switch is hidden; in-app reminders still work.
+#   npx web-push generate-vapid-keys
+#   npx convex env set VAPID_PUBLIC_KEY <public-key>
+#   npx convex env set VAPID_PRIVATE_KEY <private-key>
+#   npx convex env set VAPID_SUBJECT mailto:<your-email>


### PR DESCRIPTION
Contributors can run qali without VAPID keys: reminders still show in-app and in an open tab, and the push switch is hidden until a pair is set. CONTRIBUTING.md gains a short optional section (mirroring the AI assistant one) and the backend env example notes the same.

🤖 Generated with [Claude Code](https://claude.com/claude-code)